### PR TITLE
Bugfix: read zarr from s3

### DIFF
--- a/bioio_ome_zarr/reader.py
+++ b/bioio_ome_zarr/reader.py
@@ -4,7 +4,7 @@ import warnings
 from typing import Any, Dict, List, Optional, Tuple
 
 import xarray as xr
-from bioio_base import constants, dimensions, exceptions, io, reader, types
+from bioio_base import constants, dimensions, exceptions, reader, types
 from fsspec.spec import AbstractFileSystem
 from ome_zarr.io import parse_url
 from ome_zarr.reader import Reader as ZarrReader
@@ -44,7 +44,6 @@ class Reader(reader.Reader):
     _current_scene_index: int = 0
     # Do not provide default value because
     # they may not need to be used by your reader (i.e. input param is an array)
-    _fs: "AbstractFileSystem"
     _path: str
 
     # Required Methods
@@ -54,18 +53,12 @@ class Reader(reader.Reader):
         image: types.PathLike,
         fs_kwargs: Dict[str, Any] = {},
     ):
-        # Expand details of provided image
-        self._fs, _ = io.pathlike_to_fs(
-            image,
-            enforce_exists=False,
-            fs_kwargs=fs_kwargs,
-        )
         # pathlike_to_fs returns a file-system-specific path, but ZarrReader expects a
         # fully-qualified path.
         self._path = str(image)
 
         # Enforce valid image
-        if not self._is_supported_image(self._fs, self._path):
+        if not self._is_supported_image(None, self._path):
             raise exceptions.UnsupportedFileFormatError(
                 self.__class__.__name__, self._path
             )

--- a/bioio_ome_zarr/reader.py
+++ b/bioio_ome_zarr/reader.py
@@ -62,14 +62,14 @@ class Reader(reader.Reader):
                 "Could not find a .zgroup or .zarray file at the provided path.",
             )
 
-        self._zarr = ZarrReader(parse_url(self._path, mode="r")).zarr
+        self._zarr = get_zarr_reader(self._fs, self._path).zarr
         self._physical_pixel_sizes: Optional[types.PhysicalPixelSizes] = None
         self._channel_names: Optional[List[str]] = None
 
     @staticmethod
     def _is_supported_image(fs: AbstractFileSystem, path: str, **kwargs: Any) -> bool:
         try:
-            ZarrReader(parse_url(path, mode="r"))
+            get_zarr_reader(fs, path)
             return True
 
         except AttributeError:
@@ -244,3 +244,7 @@ class Reader(reader.Reader):
                 coords[dimensions.DimensionNames.Channel] = channel_names
 
         return coords
+
+
+def get_zarr_reader(fs: AbstractFileSystem, path: str) -> ZarrReader:
+    return ZarrReader(parse_url(fs.unstrip_protocol(path), mode="r"))

--- a/bioio_ome_zarr/reader.py
+++ b/bioio_ome_zarr/reader.py
@@ -21,17 +21,10 @@ class Reader(reader.Reader):
 
     Parameters
     ----------
-    image: Any
-        Some type of object to read and follow the Reader specification.
+    image: types.PathLike
+        String or Path to the ZARR root
     fs_kwargs: Dict[str, Any]
-        Any specific keyword arguments to pass down to the fsspec created filesystem.
-        Default: {}
-
-    Notes
-    -----
-    It is up to the implementer of the Reader to decide which types they would like to
-    accept (certain readers may not support buffers for example).
-
+        Ignored
     """
 
     _xarray_dask_data: Optional["xr.DataArray"] = None

--- a/bioio_ome_zarr/reader.py
+++ b/bioio_ome_zarr/reader.py
@@ -53,7 +53,9 @@ class Reader(reader.Reader):
         # Enforce valid image
         if not self._is_supported_image(None, self._path):
             raise exceptions.UnsupportedFileFormatError(
-                self.__class__.__name__, self._path
+                self.__class__.__name__,
+                self._path,
+                "Could not find a .zgroup or .zarray file at the provided path.",
             )
 
         self._zarr = ZarrReader(parse_url(self._path, mode="r")).zarr

--- a/bioio_ome_zarr/reader.py
+++ b/bioio_ome_zarr/reader.py
@@ -55,11 +55,14 @@ class Reader(reader.Reader):
         fs_kwargs: Dict[str, Any] = {},
     ):
         # Expand details of provided image
-        self._fs, self._path = io.pathlike_to_fs(
+        self._fs, _ = io.pathlike_to_fs(
             image,
             enforce_exists=False,
             fs_kwargs=fs_kwargs,
         )
+        # pathlike_to_fs returns a file-system-specific path, but ZarrReader expects a
+        # fully-qualified path.
+        self._path = str(image)
 
         # Enforce valid image
         if not self._is_supported_image(self._fs, self._path):

--- a/bioio_ome_zarr/reader.py
+++ b/bioio_ome_zarr/reader.py
@@ -48,14 +48,11 @@ class Reader(reader.Reader):
         fs_kwargs: Dict[str, Any] = {},
     ):
         # Expand details of provided image
-        self._fs, _ = io.pathlike_to_fs(
+        self._fs, self._path = io.pathlike_to_fs(
             image,
             enforce_exists=False,
             fs_kwargs=fs_kwargs,
         )
-        # pathlike_to_fs returns a file-system-specific path, but ZarrReader expects a
-        # fully-qualified path.
-        self._path = str(image)
 
         # Enforce valid image
         if not self._is_supported_image(self._fs, self._path):

--- a/bioio_ome_zarr/reader.py
+++ b/bioio_ome_zarr/reader.py
@@ -4,7 +4,7 @@ import warnings
 from typing import Any, Dict, List, Optional, Tuple
 
 import xarray as xr
-from bioio_base import constants, dimensions, exceptions, reader, types
+from bioio_base import constants, dimensions, exceptions, io, reader, types
 from fsspec.spec import AbstractFileSystem
 from ome_zarr.io import parse_url
 from ome_zarr.reader import Reader as ZarrReader
@@ -37,6 +37,7 @@ class Reader(reader.Reader):
     _current_scene_index: int = 0
     # Do not provide default value because
     # they may not need to be used by your reader (i.e. input param is an array)
+    _fs: "AbstractFileSystem"
     _path: str
 
     # Required Methods
@@ -46,12 +47,18 @@ class Reader(reader.Reader):
         image: types.PathLike,
         fs_kwargs: Dict[str, Any] = {},
     ):
+        # Expand details of provided image
+        self._fs, _ = io.pathlike_to_fs(
+            image,
+            enforce_exists=False,
+            fs_kwargs=fs_kwargs,
+        )
         # pathlike_to_fs returns a file-system-specific path, but ZarrReader expects a
         # fully-qualified path.
         self._path = str(image)
 
         # Enforce valid image
-        if not self._is_supported_image(None, self._path):
+        if not self._is_supported_image(self._fs, self._path):
             raise exceptions.UnsupportedFileFormatError(
                 self.__class__.__name__,
                 self._path,

--- a/bioio_ome_zarr/tests/test_s3_read.py
+++ b/bioio_ome_zarr/tests/test_s3_read.py
@@ -1,0 +1,35 @@
+import numpy as np
+
+from bioio_ome_zarr import Reader
+
+
+def test_ome_zarr_reader() -> None:
+    # ARRANGE
+    uri = (
+        "s3://allencell/aics/nuc_morph_data"
+        "/data_for_analysis/baseline_colonies/20200323_09_small/raw.ome.zarr"
+    )
+    scene = "/"
+    resolution_level = 0
+
+    # ACT
+    image_container = Reader(uri, fs_kwargs=dict(anon=True))
+    image_container.set_scene(scene)
+    image_container.set_resolution_level(resolution_level)
+
+    # ASSERT
+    assert image_container.scenes == (scene,)
+    assert image_container.current_scene == scene
+    assert image_container.resolution_levels == (0, 1, 2, 3, 4)
+    assert image_container.shape == (570, 2, 42, 1248, 1824)
+    assert image_container.dtype == np.uint16
+    assert image_container.dims.order == "TCZYX"
+    assert image_container.dims.shape == (570, 2, 42, 1248, 1824)
+    assert image_container.channel_names == ["low_EGFP", "low_Bright"]
+    assert image_container.current_resolution_level == resolution_level
+    # pixel sized in (Z, Y, X) order
+    assert image_container.physical_pixel_sizes == (
+        0.53,
+        0.2708333333333333,
+        0.2708333333333333,
+    )


### PR DESCRIPTION
This pull request resolves #13

# Description of Changes

* `ome-zarr` expects a fully-qualified URI and does not accept AbstractFileSystem object. So we use `fs.unstrip_protocol` to recover the fully-qualified URI that `BioImage` has stripped the protocol from.

### Additional changes
* Improved docstring for Reader
* Added detail `UnsupportedFileFormatError` error message

# Testing
1. Added a test against a public S3 bucket to this repo (it passes on my machine).
2. Created a new project with the following dependencies and ran the following integration test (this used to error).
```python
from bioio import BioImage
path = "s3://allencell/aics/nuc_morph_data/data_for_analysis/baseline_colonies/20200323_09_small/raw.ome.zarr"
image = BioImage(path)
print(image.get_image_dask_data())
```
```
# Dependencies
"bioio-ome-zarr @ git+https://github.com/pgarrison/bioio-ome-zarr.git@bugfix/read-zarr-from-s3",
"bioimage>=0.1.3",
"bioio>=1.0.1",
```