### PR TITLE
custom implementation of is_supported_image classmethod

### DIFF
--- a/bioio_ome_zarr/reader.py
+++ b/bioio_ome_zarr/reader.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import warnings
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 import xarray as xr
@@ -79,6 +80,25 @@ class Reader(reader.Reader):
 
         except AttributeError:
             return False
+
+    @classmethod
+    def is_supported_image(
+        cls,
+        image: types.ImageLike,
+        fs_kwargs: Dict[str, Any] = {},
+        **kwargs: Any,
+    ) -> bool:
+        if isinstance(image, (str, Path)):
+            try:
+                ZarrReader(parse_url(image, mode="r"))
+                return True
+
+            except AttributeError:
+                return False
+        else:
+            return reader.Reader.is_supported_image(cls, image,
+                                                    fs_kwargs=fs_kwargs,
+                                                    **kwargs)
 
     @property
     def scenes(self) -> Tuple[str, ...]:


### PR DESCRIPTION

### Link to Relevant Issue

This pull request resolves https://github.com/bioio-devs/bioio/issues/41

### Description of Changes

Ome-zarr reader needs to do a custom check for file support - in particular in the case where we are using http, a regular fsspec existence check will fail for directory paths.