### PR TITLE
Update test ZARR path

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ img.data
 To read from private S3 buckets or public buckets using `s3://` paths, [credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) must be configured. Public buckets can be accessed without credentials by using the `https://` path.
 ```python
 from bioio import BioImage
-path = "https://allencell.s3.amazonaws.com/aics/nuc_morph_data/data_for_analysis/baseline_colonies/20200323_09_small/raw.ome.zarr"
+path = "https://allencell.s3.amazonaws.com/aics/nuc-morph-dataset/hipsc_fov_nuclei_timelapse_dataset/hipsc_fov_nuclei_timelapse_data_used_for_analysis/baseline_colonies_fov_timelapse_dataset/20200323_09_small/raw.ome.zarr"
 image = BioImage(path)
 print(image.get_image_dask_data())
 ```

--- a/bioio_ome_zarr/tests/test_s3_read.py
+++ b/bioio_ome_zarr/tests/test_s3_read.py
@@ -9,7 +9,8 @@ def test_ome_zarr_reader() -> None:
         # Cannot use s3:// URL due to ome-zarr issue #369
         # "s3://allencell/aics/nuc_morph_data"
         "https://allencell.s3.amazonaws.com/aics/nuc-morph-dataset"
-        "/hipsc_fov_nuclei_timelapse_dataset/hipsc_fov_nuclei_timelapse_data_used_for_analysis"
+        "/hipsc_fov_nuclei_timelapse_dataset"
+        "/hipsc_fov_nuclei_timelapse_data_used_for_analysis"
         "/baseline_colonies_fov_timelapse_dataset/20200323_09_small/raw.ome.zarr"
     )
     scene = "/"

--- a/bioio_ome_zarr/tests/test_s3_read.py
+++ b/bioio_ome_zarr/tests/test_s3_read.py
@@ -8,8 +8,9 @@ def test_ome_zarr_reader() -> None:
     uri = (
         # Cannot use s3:// URL due to ome-zarr issue #369
         # "s3://allencell/aics/nuc_morph_data"
-        "https://allencell.s3.amazonaws.com/aics/nuc_morph_data"
-        "/data_for_analysis/baseline_colonies/20200323_09_small/raw.ome.zarr"
+        "https://allencell.s3.amazonaws.com/aics/nuc-morph-dataset"
+        "/hipsc_fov_nuclei_timelapse_dataset/hipsc_fov_nuclei_timelapse_data_used_for_analysis"
+        "/baseline_colonies_fov_timelapse_dataset/20200323_09_small/raw.ome.zarr"
     )
     scene = "/"
     resolution_level = 0


### PR DESCRIPTION
# Context
One test uses real (i.e., not specifically for testing) data. The scientific project publishing the data has moved the file from the `nuc_morph_data` folder to the `nuc-morph-dataset` folder. The new location is visible [here on quilt](https://open.quiltdata.com/b/allencell/tree/aics/nuc-morph-dataset/hipsc_fov_nuclei_timelapse_dataset/hipsc_fov_nuclei_timelapse_data_used_for_analysis/baseline_colonies_fov_timelapse_dataset/20200323_09_small/raw.ome.zarr/). The file at the old path will soon be removed.

# Change
Update the path in the test.

# Testing
`pytest bioio_ome_zarr/tests/test_s3_read.py`