### PR TITLE
Public s3 prefix without auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,18 @@ img.data
 ```
 
 ### Reading from AWS S3
-To read from private S3 buckets or public buckets using `s3://` paths, [credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) must be configured. Public buckets can be accessed without credentials by using the `https://` path.
+To read from private S3 buckets, [credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) must be configured. Public buckets can be accessed without credentials.
 ```python
 from bioio import BioImage
 path = "https://allencell.s3.amazonaws.com/aics/nuc-morph-dataset/hipsc_fov_nuclei_timelapse_dataset/hipsc_fov_nuclei_timelapse_data_used_for_analysis/baseline_colonies_fov_timelapse_dataset/20200323_09_small/raw.ome.zarr"
 image = BioImage(path)
+print(image.get_image_dask_data())
+```
+If using an `s3://` path to access a public S3 bucket, the `BioImage` constructor must be given a dictionary with `anon: True` in the `fs_kwargs` argument.
+```python
+from bioio import BioImage
+path = "s3://allencell/aics/nuc-morph-dataset/hipsc_fov_nuclei_timelapse_dataset/hipsc_fov_nuclei_timelapse_data_used_for_analysis/baseline_colonies_fov_timelapse_dataset/20200323_09_small/raw.ome.zarr"
+image = BioImage(path, fs_kwargs=dict(anon=True))
 print(image.get_image_dask_data())
 ```
 

--- a/bioio_ome_zarr/reader.py
+++ b/bioio_ome_zarr/reader.py
@@ -8,7 +8,7 @@ import xarray as xr
 import zarr.storage
 from bioio_base import constants, dimensions, exceptions, io, reader, types
 from fsspec.spec import AbstractFileSystem
-from ome_zarr.io import parse_url, ZarrLocation
+from ome_zarr.io import ZarrLocation
 from ome_zarr.reader import Reader as ZarrReader
 
 from . import utils as metadata_utils

--- a/bioio_ome_zarr/reader.py
+++ b/bioio_ome_zarr/reader.py
@@ -5,9 +5,10 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 import xarray as xr
+import zarr.storage
 from bioio_base import constants, dimensions, exceptions, io, reader, types
 from fsspec.spec import AbstractFileSystem
-from ome_zarr.io import parse_url
+from ome_zarr.io import parse_url, ZarrLocation
 from ome_zarr.reader import Reader as ZarrReader
 
 from . import utils as metadata_utils
@@ -25,7 +26,7 @@ class Reader(reader.Reader):
     image: types.PathLike
         String or Path to the ZARR root
     fs_kwargs: Dict[str, Any]
-        Ignored
+        Passed to fsspec. For public S3 buckets, use {"anon": True}.
     """
 
     _xarray_dask_data: Optional["xr.DataArray"] = None
@@ -264,5 +265,5 @@ class Reader(reader.Reader):
 
 def get_zarr_reader(fs: AbstractFileSystem, path: str) -> ZarrReader:
     if fs is not None:
-        path = fs.unstrip_protocol(path)
+        return ZarrReader(ZarrLocation(zarr.storage.FSStore(url=path, fs=fs)))
     return ZarrReader(parse_url(path, mode="r"))

--- a/bioio_ome_zarr/reader.py
+++ b/bioio_ome_zarr/reader.py
@@ -76,7 +76,8 @@ class Reader(reader.Reader):
             return True
 
         except (AssertionError, AttributeError):
-            # AssertionError may be raised by ZarrReader.__init__ which calls zarr.exists()
+            # AssertionError may be raised by ZarrReader.__init__ which calls
+            # zarr.exists()
             return False
 
     @classmethod

--- a/bioio_ome_zarr/reader.py
+++ b/bioio_ome_zarr/reader.py
@@ -75,7 +75,8 @@ class Reader(reader.Reader):
             get_zarr_reader(fs, path)
             return True
 
-        except AttributeError:
+        except (AssertionError, AttributeError):
+            # AssertionError may be raised by ZarrReader.__init__ which calls zarr.exists()
             return False
 
     @classmethod

--- a/bioio_ome_zarr/reader.py
+++ b/bioio_ome_zarr/reader.py
@@ -264,6 +264,4 @@ class Reader(reader.Reader):
 
 
 def get_zarr_reader(fs: AbstractFileSystem, path: str) -> ZarrReader:
-    if fs is not None:
-        return ZarrReader(ZarrLocation(zarr.storage.FSStore(url=path, fs=fs)))
-    return ZarrReader(parse_url(path, mode="r"))
+    return ZarrReader(ZarrLocation(zarr.storage.FSStore(url=path, fs=fs)))

--- a/bioio_ome_zarr/tests/test_s3_read.py
+++ b/bioio_ome_zarr/tests/test_s3_read.py
@@ -11,7 +11,7 @@ from bioio_ome_zarr import Reader
         ["https://allencell.s3.amazonaws.com/aics/", dict()],
     ],
 )
-def test_ome_zarr_reader(prefix, fs_kwargs) -> None:
+def test_ome_zarr_reader(prefix: str, fs_kwargs: dict) -> None:
     # ARRANGE
     uri = (
         prefix + "nuc-morph-dataset"

--- a/bioio_ome_zarr/tests/test_s3_read.py
+++ b/bioio_ome_zarr/tests/test_s3_read.py
@@ -1,14 +1,20 @@
 import numpy as np
+import pytest
 
 from bioio_ome_zarr import Reader
 
 
-def test_ome_zarr_reader() -> None:
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        "s3://allencell/aics/nuc_morph_data",
+        "https://allencell.s3.amazonaws.com/aics/",
+    ],
+)
+def test_ome_zarr_reader(prefix) -> None:
     # ARRANGE
     uri = (
-        # Cannot use s3:// URL due to ome-zarr issue #369
-        # "s3://allencell/aics/nuc_morph_data"
-        "https://allencell.s3.amazonaws.com/aics/nuc-morph-dataset"
+        prefix + "nuc-morph-dataset"
         "/hipsc_fov_nuclei_timelapse_dataset"
         "/hipsc_fov_nuclei_timelapse_data_used_for_analysis"
         "/baseline_colonies_fov_timelapse_dataset/20200323_09_small/raw.ome.zarr"

--- a/bioio_ome_zarr/tests/test_s3_read.py
+++ b/bioio_ome_zarr/tests/test_s3_read.py
@@ -5,13 +5,13 @@ from bioio_ome_zarr import Reader
 
 
 @pytest.mark.parametrize(
-    "prefix",
+    ["prefix", "fs_kwargs"],
     [
-        "s3://allencell/aics/nuc_morph_data",
-        "https://allencell.s3.amazonaws.com/aics/",
+        ["s3://allencell/aics/", dict(anon=True)],
+        ["https://allencell.s3.amazonaws.com/aics/", dict()],
     ],
 )
-def test_ome_zarr_reader(prefix) -> None:
+def test_ome_zarr_reader(prefix, fs_kwargs) -> None:
     # ARRANGE
     uri = (
         prefix + "nuc-morph-dataset"
@@ -23,7 +23,7 @@ def test_ome_zarr_reader(prefix) -> None:
     resolution_level = 0
 
     # ACT
-    image_container = Reader(uri, fs_kwargs=dict(anon=True))
+    image_container = Reader(uri, fs_kwargs=fs_kwargs)
     image_container.set_scene(scene)
     image_container.set_resolution_level(resolution_level)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,6 @@
 requires = ["setuptools>=65", "wheel", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools_scm]
-
-# package basics
-# https://peps.python.org/pep-0621/
 [project]
 name = "bioio-ome-zarr"
 description = "A BioIO reader plugin for reading Zarr files in the OME format."
@@ -27,10 +23,11 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-  "bioio-base>=1.0.0",
-  "fsspec>=2022.8.0",
-  "ome-zarr>=0.8.0",
-  "xarray>=0.16.1",
+    "bioio-base>=1.0.0",
+    "fsspec>=2022.8.0",
+    "ome-zarr>=0.9.0",
+    "xarray>=0.16.1",
+    "zarr>=2.18.2",
 ]
 
 [project.urls]


### PR DESCRIPTION
Trying again to do #25 but with the tests fixed this time!

# Context
Previously bioio could not read from a public `s3://` URL without AWS authentication due to [this ome-zarr issue](https://github.com/ome/ome-zarr-py/issues/369). As of `0.9.0` the issue is resolved.

# Changes
* Upgrade `ome-zarr` dependency
* Pass an fsspec instance to `ome-zarr` instead of just a path
* Add a test with a public `s3://` URL

# Testing
`pdm run pytest bioio_ome_zarr/tests/test_s3_read.py`