### PR TITLE
 bugfix/cloud_metadata_update

### DIFF
--- a/bioio_ome_zarr/tests/test_s3_read.py
+++ b/bioio_ome_zarr/tests/test_s3_read.py
@@ -37,7 +37,7 @@ def test_ome_zarr_reader(prefix: str, fs_kwargs: dict) -> None:
     assert image_container.dims.shape == (570, 2, 42, 1248, 1824)
     assert image_container.channel_names == ["EGFP", "Bright"]
     assert image_container.current_resolution_level == resolution_level
-    
+
     # pixel sized in (Z, Y, X) order
     assert image_container.physical_pixel_sizes == (
         0.7579,

--- a/bioio_ome_zarr/tests/test_s3_read.py
+++ b/bioio_ome_zarr/tests/test_s3_read.py
@@ -35,11 +35,12 @@ def test_ome_zarr_reader(prefix: str, fs_kwargs: dict) -> None:
     assert image_container.dtype == np.uint16
     assert image_container.dims.order == "TCZYX"
     assert image_container.dims.shape == (570, 2, 42, 1248, 1824)
-    assert image_container.channel_names == ["low_EGFP", "low_Bright"]
+    assert image_container.channel_names == ["EGFP", "Bright"]
     assert image_container.current_resolution_level == resolution_level
     # pixel sized in (Z, Y, X) order
+    a = image_container.physical_pixel_sizes
     assert image_container.physical_pixel_sizes == (
-        0.53,
+        0.7579,
         0.2708333333333333,
         0.2708333333333333,
     )

--- a/bioio_ome_zarr/tests/test_s3_read.py
+++ b/bioio_ome_zarr/tests/test_s3_read.py
@@ -37,8 +37,8 @@ def test_ome_zarr_reader(prefix: str, fs_kwargs: dict) -> None:
     assert image_container.dims.shape == (570, 2, 42, 1248, 1824)
     assert image_container.channel_names == ["EGFP", "Bright"]
     assert image_container.current_resolution_level == resolution_level
+    
     # pixel sized in (Z, Y, X) order
-    a = image_container.physical_pixel_sizes
     assert image_container.physical_pixel_sizes == (
         0.7579,
         0.2708333333333333,


### PR DESCRIPTION
### Description 

A few of our zarr cloud tests are dependent on nucmorph production files, these files recently had updates to channel names and physical pixel size. As a result of this, our tests are out of date. This PR just updates the tests to reflect the new metadata.