### PR TITLE
Bugfix/pps scene reset

### DIFF
--- a/bioio_ome_zarr/reader.py
+++ b/bioio_ome_zarr/reader.py
@@ -182,8 +182,7 @@ class Reader(reader.Reader):
             warnings.warn(f"Could not parse zarr pixel size: {e}")
             z_size, y_size, x_size = None, None, None
 
-        self._physical_pixel_sizes = types.PhysicalPixelSizes(z_size, y_size, x_size)
-        return self._physical_pixel_sizes
+        return types.PhysicalPixelSizes(z_size, y_size, x_size)
 
     def _get_pixel_size(
         self,

--- a/bioio_ome_zarr/reader.py
+++ b/bioio_ome_zarr/reader.py
@@ -182,9 +182,7 @@ class Reader(reader.Reader):
             warnings.warn(f"Could not parse zarr pixel size: {e}")
             z_size, y_size, x_size = None, None, None
 
-        self._physical_pixel_sizes = types.PhysicalPixelSizes(
-            z_size, y_size, x_size
-        )
+        self._physical_pixel_sizes = types.PhysicalPixelSizes(z_size, y_size, x_size)
         return self._physical_pixel_sizes
 
     def _get_pixel_size(

--- a/bioio_ome_zarr/reader.py
+++ b/bioio_ome_zarr/reader.py
@@ -174,18 +174,17 @@ class Reader(reader.Reader):
     @property
     def physical_pixel_sizes(self) -> types.PhysicalPixelSizes:
         """Return the physical pixel sizes of the image."""
-        if self._physical_pixel_sizes is None:
-            try:
-                z_size, y_size, x_size = self._get_pixel_size(
-                    list(self.dims.order),
-                )
-            except Exception as e:
-                warnings.warn(f"Could not parse zarr pixel size: {e}")
-                z_size, y_size, x_size = None, None, None
-
-            self._physical_pixel_sizes = types.PhysicalPixelSizes(
-                z_size, y_size, x_size
+        try:
+            z_size, y_size, x_size = self._get_pixel_size(
+                list(self.dims.order),
             )
+        except Exception as e:
+            warnings.warn(f"Could not parse zarr pixel size: {e}")
+            z_size, y_size, x_size = None, None, None
+
+        self._physical_pixel_sizes = types.PhysicalPixelSizes(
+            z_size, y_size, x_size
+        )
         return self._physical_pixel_sizes
 
     def _get_pixel_size(


### PR DESCRIPTION
### Description 

This PR resolves https://github.com/bioio-devs/bioio-base/issues/33 Now that we reset the physical pixel size in-between scene changes to `PhysicalPixelSizes(null, null,null)` the previous logic was not re-evaluating the PPS since it was `PhysicalPixelSizes(null, null,null)` not pure `null`.  This PR removes the if statement that was the previous indicator for reevaluation and reevaluates each time it is called.  We pull the value from the root attrs so it's not a computationally intense procedure.

Alternatively we could change the if statement to check if any of the elements of PPS are `null`