### PR TITLE
Zarr V3 Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", 3.11, 3.12, 3.13]
+        python-version: [ 3.11, 3.12, 3.13]
         os: [ubuntu-latest, macOS-latest, windows-latest]
     env:
       BUCKET_NAME : "bioio-dev-test-resources"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://github.com/bioio-devs/bioio-ome-zarr/actions/workflows/ci.yml/badge.svg)](https://github.com/bioio-devs/bioio-ome-zarr/actions)
 [![PyPI version](https://badge.fury.io/py/bioio-ome-zarr.svg)](https://badge.fury.io/py/bioio-ome-zarr)
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
-[![Python 3.10–3.13](https://img.shields.io/badge/python-3.10--3.13-blue.svg)](https://www.python.org/downloads/)
+[![Python 3.11–3.13](https://img.shields.io/badge/python-3.11--3.13-blue.svg)](https://www.python.org/downloads/)
 
 A BioIO reader plugin for reading OME ZARR images using `ome-zarr`
 

--- a/bioio_ome_zarr/__init__.py
+++ b/bioio_ome_zarr/__init__.py
@@ -2,7 +2,10 @@
 
 """Top-level package for bioio_ome_zarr."""
 
+import os
 from importlib.metadata import PackageNotFoundError, version
+
+os.environ.setdefault("ZARR_V3_EXPERIMENTAL_API", "1")
 
 try:
     __version__ = version("bioio-ome-zarr")

--- a/bioio_ome_zarr/reader.py
+++ b/bioio_ome_zarr/reader.py
@@ -117,11 +117,11 @@ class Reader(reader.Reader):
         return self._scenes
 
     def _get_ome_dims(self) -> Tuple[str, ...]:
-        ms = self._multiscales_metadata[self._current_scene_index]
-        axes = ms.get("axes", [])
+        multiscales = self._multiscales_metadata[self._current_scene_index]
+        axes = multiscales.get("axes", [])
         if axes:
             return tuple(ax["name"].upper() for ax in axes)
-        datasets = ms.get("datasets", [])
+        datasets = multiscales.get("datasets", [])
         if datasets and datasets[0].get("path") is not None:
             arr = self._zarr[datasets[0]["path"]]
             return tuple(Reader._guess_dim_order(arr.shape))
@@ -137,8 +137,8 @@ class Reader(reader.Reader):
             By default these are ordered from highest resolution to lowest
             resolution.
         """
-        ms = self._multiscales_metadata[self._current_scene_index]
-        return tuple(range(len(ms.get("datasets", []))))
+        multiscales = self._multiscales_metadata[self._current_scene_index]
+        return tuple(range(len(multiscales.get("datasets", []))))
 
     def _read_delayed(self) -> xr.DataArray:
         return self._xarr_format(delayed=True)
@@ -167,8 +167,8 @@ class Reader(reader.Reader):
         * Attaches the original Zarr attributes under
           `constants.METADATA_UNPROCESSED`.
         """
-        ms = self._multiscales_metadata[self._current_scene_index]
-        datasets = ms.get("datasets", [])
+        multiscales = self._multiscales_metadata[self._current_scene_index]
+        datasets = multiscales.get("datasets", [])
         data_path = datasets[self._current_resolution_level].get("path")
         arr = self._zarr[data_path]
 
@@ -244,11 +244,11 @@ class Reader(reader.Reader):
         scale : list of float
             The elementwise product of the global and dataset-specific scales.
         """
-        ms = self._multiscales_metadata[self._current_scene_index]
-        overall_scale = ms.get(
+        multiscales = self._multiscales_metadata[self._current_scene_index]
+        overall_scale = multiscales.get(
             "coordinateTransformations", [{"scale": [1.0] * len(dims)}]
         )[0]["scale"]
-        ds_scale = ms["datasets"][self._current_resolution_level][
+        ds_scale = multiscales["datasets"][self._current_resolution_level][
             "coordinateTransformations"
         ][0]["scale"]
         return [o * d for o, d in zip(overall_scale, ds_scale)]

--- a/bioio_ome_zarr/reader.py
+++ b/bioio_ome_zarr/reader.py
@@ -140,10 +140,6 @@ class Reader(reader.Reader):
         ms = self._multiscales_metadata[self._current_scene_index]
         return tuple(range(len(ms.get("datasets", []))))
 
-    @property
-    def current_scene(self) -> str:
-        return self.scenes[self._current_scene_index]
-
     def _read_delayed(self) -> xr.DataArray:
         return self._xarr_format(delayed=True)
 

--- a/bioio_ome_zarr/reader.py
+++ b/bioio_ome_zarr/reader.py
@@ -35,6 +35,8 @@ class Reader(reader.Reader):
     _fs: AbstractFileSystem
     _path: str
 
+    _current_scene_index: int = 0
+
     def __init__(
         self,
         image: types.PathLike,

--- a/bioio_ome_zarr/reader.py
+++ b/bioio_ome_zarr/reader.py
@@ -111,15 +111,18 @@ class Reader(reader.Reader):
             A tuple of valid scene ids in the file.
         """
         if self._scenes is None:
-            if all("name" in scene for scene in self._multiscales_metadata):
-                self._scenes = tuple(
-                    scene["name"] for scene in self._multiscales_metadata
-                )
+            scenes = [scene.get("name") for scene in self._multiscales_metadata]
+
+            # Check that every name exists and that they're all unique
+            if all(scenes) and len(set(scenes)) == len(scenes):
+                self._scenes = tuple(scenes)
             else:
+                # Otherwise generate default IDs by index
                 self._scenes = tuple(
                     metadata_utils.generate_ome_image_id(i)
                     for i in range(len(self._multiscales_metadata))
                 )
+
         return self._scenes
 
     def _get_ome_dims(self) -> Tuple[str, ...]:

--- a/bioio_ome_zarr/reader.py
+++ b/bioio_ome_zarr/reader.py
@@ -220,6 +220,7 @@ class Reader(reader.Reader):
         """
         coords = {}
         if dimensions.DimensionNames.Channel in dims:
+            # Generate channel names if no existing channel names
             if channel_names is None:
                 coords[dimensions.DimensionNames.Channel] = [
                     metadata_utils.generate_ome_channel_id(scene, i)

--- a/bioio_ome_zarr/tests/test_http_read.py
+++ b/bioio_ome_zarr/tests/test_http_read.py
@@ -68,7 +68,7 @@ ome_host = "https://uk1s3.embassy.ebi.ac.uk/ebi-ngff-challenge-2024/"
         ),
     ],
 )
-def test_ome_zarr_reader(
+def test_https_read_zarrV3(
     uri: str,
     set_scene: str,
     set_resolution_level: int,

--- a/bioio_ome_zarr/tests/test_http_read.py
+++ b/bioio_ome_zarr/tests/test_http_read.py
@@ -1,0 +1,103 @@
+from typing import List, Tuple
+
+import numpy as np
+import pytest
+from bioio_base import dimensions
+
+from bioio_ome_zarr import Reader
+
+ome_host = "https://uk1s3.embassy.ebi.ac.uk/ebi-ngff-challenge-2024/"
+
+
+@pytest.mark.parametrize(
+    "uri, "
+    "set_scene, "
+    "expected_scenes, "
+    "set_resolution_level, "
+    "expected_resolution_levels, "
+    "expected_shape, "
+    "expected_dtype, "
+    "expected_dims_order, "
+    "expected_channel_names, "
+    "expected_physical_pixel_sizes, "
+    "expected_time_interval, "
+    "expected_scale",
+    [
+        # General Zarr
+        (
+            f"{ome_host}fb416517-e36d-4bdb-98f9-47b644138d47.zarr",
+            "Image:0",
+            "Image:0",
+            0,
+            (0, 1, 2),
+            (1, 1, 190, 617, 617),
+            np.float32,
+            dimensions.DEFAULT_DIMENSION_ORDER,
+            ["Channel 0"],
+            (1.0, 1.0, 1.0),
+            1.0,
+            (1.0, 1.0, 1.0, 1.0, 1.0),
+        ),
+        (
+            f"{ome_host}4ffaeed2-fa70-4907-820f-8a96ef683095.zarr",
+            "",
+            "",
+            0,
+            (0, 1),
+            (1, 2, 1, 512, 512),
+            np.uint8,
+            dimensions.DEFAULT_DIMENSION_ORDER,
+            ["AF555-T1", "AF488-T2"],
+            (1.0, 0.22007964065255714, 0.22007964065255714),
+            1.0,
+            (1.0, 1.0, 1.0, 0.22007964065255714, 0.22007964065255714),
+        ),
+        (
+            f"{ome_host}c0e5d621-62cc-43a6-9dad-2ddab8959d17.zarr",
+            "",
+            "",
+            0,
+            (0, 1, 2),
+            (163, 2, 1, 1024, 1024),
+            np.uint16,
+            dimensions.DEFAULT_DIMENSION_ORDER,
+            ["GFP", "DsRed"],
+            (1.0, 6.8746696041186794, 6.8746696041186794),
+            1.8112843,
+            (1.8112843, 1.0, 1.0, 6.8746696041186794, 6.8746696041186794),
+        ),
+    ],
+)
+def test_ome_zarr_reader(
+    uri: str,
+    set_scene: str,
+    set_resolution_level: int,
+    expected_scenes: Tuple[str, ...],
+    expected_resolution_levels: Tuple[int, ...],
+    expected_shape: Tuple[int, ...],
+    expected_dtype: np.dtype,
+    expected_dims_order: str,
+    expected_channel_names: List[str],
+    expected_physical_pixel_sizes: Tuple[float, float, float],
+    expected_time_interval: float,
+    expected_scale: Tuple[float, float, float, float, float],
+) -> None:
+    # Run checks
+    image_container = Reader(uri)
+    image_container.set_scene(set_scene)
+    image_container.set_resolution_level(set_resolution_level)
+
+    # ASSERT
+    assert image_container.scenes == (expected_scenes,)
+    assert image_container.current_scene == expected_scenes
+    assert image_container.resolution_levels == expected_resolution_levels
+    assert image_container.shape == expected_shape
+    assert image_container.dtype == expected_dtype
+    assert image_container.dims.order == expected_dims_order
+    assert image_container.channel_names == expected_channel_names
+    assert image_container.current_resolution_level == set_resolution_level
+
+    # temporal and spatial scaling information
+    assert image_container.physical_pixel_sizes == expected_physical_pixel_sizes
+    assert image_container.time_interval == expected_time_interval
+    assert image_container.scale == expected_scale

--- a/bioio_ome_zarr/tests/test_http_read.py
+++ b/bioio_ome_zarr/tests/test_http_read.py
@@ -40,8 +40,8 @@ ome_host = "https://uk1s3.embassy.ebi.ac.uk/ebi-ngff-challenge-2024/"
         ),
         (
             f"{ome_host}4ffaeed2-fa70-4907-820f-8a96ef683095.zarr",
-            "",
-            "",
+            "Image:0",
+            "Image:0",
             0,
             (0, 1),
             (1, 2, 1, 512, 512),
@@ -54,8 +54,8 @@ ome_host = "https://uk1s3.embassy.ebi.ac.uk/ebi-ngff-challenge-2024/"
         ),
         (
             f"{ome_host}c0e5d621-62cc-43a6-9dad-2ddab8959d17.zarr",
-            "",
-            "",
+            "Image:0",
+            "Image:0",
             0,
             (0, 1, 2),
             (163, 2, 1, 1024, 1024),

--- a/bioio_ome_zarr/tests/test_reader.py
+++ b/bioio_ome_zarr/tests/test_reader.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Tuple
 import numpy as np
 import pytest
 from bioio_base import dimensions, exceptions, test_utilities
+from zarr.core.group import GroupMetadata
 
 from bioio_ome_zarr import Reader
 
@@ -203,7 +204,7 @@ def test_ome_zarr_reader(
         expected_dims_order=expected_dims_order,
         expected_channel_names=expected_channel_names,
         expected_physical_pixel_sizes=expected_physical_pixel_sizes,
-        expected_metadata_type=dict,
+        expected_metadata_type=GroupMetadata,
     )
 
 

--- a/bioio_ome_zarr/tests/test_reader_zarrV2.py
+++ b/bioio_ome_zarr/tests/test_reader_zarrV2.py
@@ -205,6 +205,7 @@ def test_ome_zarr_reader(
         expected_channel_names=expected_channel_names,
         expected_physical_pixel_sizes=expected_physical_pixel_sizes,
         expected_metadata_type=GroupMetadata,
+        reader_kwargs={},
     )
 
 

--- a/bioio_ome_zarr/tests/test_reader_zarrV3.py
+++ b/bioio_ome_zarr/tests/test_reader_zarrV3.py
@@ -1,0 +1,3 @@
+# Placeholder
+
+# This file should contain test for local V3 files once converted

--- a/bioio_ome_zarr/tests/test_s3_read.py
+++ b/bioio_ome_zarr/tests/test_s3_read.py
@@ -11,7 +11,7 @@ from bioio_ome_zarr import Reader
         ["https://allencell.s3.amazonaws.com/aics/", dict()],
     ],
 )
-def test_ome_zarr_reader(prefix: str, fs_kwargs: dict) -> None:
+def test_ome_zarr_reader_zarrV2(prefix: str, fs_kwargs: dict) -> None:
     # ARRANGE
     uri = (
         prefix + "nuc-morph-dataset"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dynamic = ["version"]
 dependencies = [
     "bioio-base>=1.0.0",
     "fsspec>=2022.8.0",
+    "s3fs>=2023.9.0",
     "xarray>=0.16.1",
     "zarr>=3.0.6",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,8 @@ dynamic = ["version"]
 dependencies = [
     "bioio-base>=1.0.0",
     "fsspec>=2022.8.0",
-    "ome-zarr>=0.9.0",
     "xarray>=0.16.1",
-    "zarr>=2.18.2",
+    "zarr>=3.0.6",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ name = "bioio-ome-zarr"
 description = "A BioIO reader plugin for reading Zarr files in the OME format."
 keywords = []
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 license = { text = "MIT License" }
 authors = [
   { email = "brian.whitney@alleninstitute.org", name = "bioio-devs" },
@@ -19,7 +19,6 @@ authors = [
 classifiers = [
   "Development Status :: 4 - Beta",
   "Natural Language :: English",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
@@ -106,7 +105,7 @@ show_error_codes = true
 [tool.flake8]
 max-line-length = 88
 ignore = "E203,E402,W291,W503"
-min-python-version = "3.10.0"
+min-python-version = "3.11.0"
 per-file-ignores = [
   "__init__.py:F401",
 ]


### PR DESCRIPTION
## Description
The purpose of this PR is to add support for reading Zarr3 files. Additionally we want to continue to support reading Zarr2


### Design Decisions 

- This PR suggests we drop python 3.10 (for reader only), if we don't we cannot read zarr 3
- This PR is incompatible with the current version of `bioio` since `bioio` pins zarr below the zarr 3 support threshold
- This PR  drops `ome-zarr` since it doesn't read zarr 3 and opts for our own internal support of ome 0.5.0