### PR TITLE
Add benchmark workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     - uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: arn:aws:iam::978220035532:role/bioio_github
-        role-session-name: bioio-lif-${{ github.sha }}
+        role-session-name: bioio-ome-zarr-${{ github.sha }}
         aws-region: ${{ env.AWS_REGION }}
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,0 +1,56 @@
+name: Performance Benchmark
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  # Check tests pass on multiple Python and OS combinations
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+    env:
+      BUCKET_NAME : "bioio-dev-test-resources"
+      AWS_REGION : "us-west-2"
+    permissions:
+      id-token: write   # This is required for requesting the JWT
+      contents: read    # This is required for actions/checkout
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: arn:aws:iam::978220035532:role/bioio_github
+        role-session-name: bioio-ome-zarr-${{ github.sha }}
+        aws-region: ${{ env.AWS_REGION }}
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.13
+    - uses: extractions/setup-just@v3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Install Dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install .
+    - uses: actions/cache@v4
+      id: cache
+      with:
+        path: bioio_ome_zarr/tests/resources
+        key: ${{ hashFiles('scripts/TEST_RESOURCES_HASH.txt') }}
+    - name: Download Test Resources
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: |
+        python scripts/download_test_resources.py --debug
+    - name: Run Performance Benchmark
+      run: just benchmark
+    - name: Upload Performance Results
+      uses: actions/upload-artifact@v4
+      with:
+        if-no-files-found: error

--- a/Justfile
+++ b/Justfile
@@ -36,6 +36,10 @@ lint:
 test:
 	pytest --cov-report xml --cov-report html --cov=bioio_ome_zarr bioio_ome_zarr/tests
 
+# run performance tests
+benchmark:
+	python scripts/benchmark.py
+
 # run lint and then run tests
 build:
 	just lint

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -1,0 +1,12 @@
+"""
+    Runs bioio_base's benchmark function against the test resources in this repository
+"""
+import pathlib
+
+import bioio_base.benchmark
+
+import bioio_ome_zarr
+
+
+test_resources_dir = pathlib.Path(__file__).parent.parent / "bioio_ome_zarr" / "tests" / "resources"
+bioio_base.benchmark.benchmark(bioio_ome_zarr.reader.Reader, test_resources_dir)


### PR DESCRIPTION
### Link to Relevant Issue

This pull request is related to #40

### Description of Changes

This adds a workflow for doing some performance benchmarking on each push to main while also making it accessible to developers through the `just` command. This relies on the [benchmark functionality added via this other PR](https://github.com/bioio-devs/bioio-base/pull/41)

### Testing
I've tested this while installing the bioio-base directly from main, but to accurately test the workflow I need to release bioio-base first (unless anyone has cool ideas)
