### PR TITLE
bugfix/config-for-level-scale

### DIFF
--- a/bioio_ome_zarr/tests/writers/test_config.py
+++ b/bioio_ome_zarr/tests/writers/test_config.py
@@ -1,55 +1,84 @@
-from typing import Tuple
+import inspect
+from typing import List, Tuple
 
 import numpy as np
 import pytest
+import zarr
 
 from bioio_ome_zarr.writers import (
+    OMEZarrWriter,
     get_default_config_for_ml,
     get_default_config_for_viz,
 )
 
 
-@pytest.mark.parametrize("shape", [(1, 1, 4, 16, 8), (4, 4)])
-def test_viz_preset_cfg(shape: Tuple[int, ...]) -> None:
-    data = np.zeros(shape, dtype=np.uint8)
+def _allowed_writer_keys() -> List[str]:
+    """Kwarg names accepted by OMEZarrWriter.__init__ (minus 'self')."""
+    sig = inspect.signature(OMEZarrWriter.__init__)
+    return [name for name in sig.parameters if name != "self"]
+
+
+@pytest.mark.parametrize("level0_shape", [(1, 1, 4, 16, 8), (4, 4)])
+def test_viz_preset_cfg(level0_shape: Tuple[int, ...]) -> None:
+    data = np.zeros(level0_shape, dtype=np.uint8)
     cfg = get_default_config_for_viz(data)
 
-    # Required keys
-    assert set(cfg.keys()) == {"shape", "dtype", "scale", "chunk_shape"}
+    # API valid
+    assert set(cfg.keys()) == {"level_shapes", "dtype", "chunk_shape"}
+    assert set(cfg.keys()).issubset(set(_allowed_writer_keys()))
 
-    # Shape and dtype match input
-    assert cfg["shape"] == shape
+    # Basic semantics
     assert cfg["dtype"] == data.dtype
+    level_shapes = cfg["level_shapes"]
+    assert len(level_shapes) == 3
+    assert tuple(level_shapes[0]) == tuple(level0_shape)
 
-    # Scale has 2 pyramid levels (XY downsampled)
-    assert isinstance(cfg["scale"], tuple)
-    assert len(cfg["scale"]) == 2
-    for vec in cfg["scale"]:
-        assert len(vec) == len(shape)
-        # Y and X entries should be < 1.0
-        assert vec[-1] < 1.0 and vec[-2] < 1.0
+    # XY pyramid: halve and quarter Y/X (floor)
+    ndim = len(level0_shape)
+    y_idx, x_idx = ndim - 2, ndim - 1
+    expected_l1 = list(level0_shape)
+    expected_l1[y_idx] = max(1, level0_shape[y_idx] // 2)
+    expected_l1[x_idx] = max(1, level0_shape[x_idx] // 2)
+    expected_l2 = list(level0_shape)
+    expected_l2[y_idx] = max(1, level0_shape[y_idx] // 4)
+    expected_l2[x_idx] = max(1, level0_shape[x_idx] // 4)
+    assert tuple(level_shapes[1]) == tuple(expected_l1)
+    assert tuple(level_shapes[2]) == tuple(expected_l2)
 
-    # Chunk shape is a tuple with ndim entries
-    assert isinstance(cfg["chunk_shape"], tuple)
-    assert len(cfg["chunk_shape"]) == len(shape)
-    assert all(isinstance(c, int) and c > 0 for c in cfg["chunk_shape"])
+    # Chunk shape
+    chunk_shape = cfg["chunk_shape"]
+    assert isinstance(chunk_shape, tuple)
+    assert len(chunk_shape) == ndim
+    assert all(isinstance(c, int) and c > 0 for c in chunk_shape)
+
+    # Constructor accepts the preset (no IO performed yet)
+    _ = OMEZarrWriter(store=zarr.storage.MemoryStore(), **cfg)
 
 
-@pytest.mark.parametrize("shape", [(1, 1, 8, 32, 16), (1, 32, 16)])
-def test_ml_preset_cfg(shape: Tuple[int, ...]) -> None:
-    data = np.zeros(shape, dtype=np.uint8)
+@pytest.mark.parametrize("level0_shape", [(1, 1, 8, 32, 16), (1, 32, 16)])
+def test_ml_preset_cfg(level0_shape: Tuple[int, ...]) -> None:
+    data = np.zeros(level0_shape, dtype=np.uint8)
     cfg = get_default_config_for_ml(data)
 
-    # Required keys
-    assert set(cfg.keys()) == {"shape", "dtype", "scale", "chunk_shape"}
+    # API valid
+    assert set(cfg.keys()) == {"level_shapes", "dtype", "chunk_shape"}
+    assert set(cfg.keys()).issubset(set(_allowed_writer_keys()))
 
-    # Shape and dtype match input
-    assert cfg["shape"] == shape
+    # Basic semantics
     assert cfg["dtype"] == data.dtype
+    assert len(cfg["level_shapes"]) == 1
+    assert tuple(cfg["level_shapes"][0]) == tuple(level0_shape)
 
-    # No pyramid
-    assert cfg["scale"] == tuple()
+    # Chunk shape
+    chunk_shape = cfg["chunk_shape"]
+    assert isinstance(chunk_shape, tuple)
+    assert len(chunk_shape) == len(level0_shape)
+    assert all(isinstance(c, int) and c > 0 for c in chunk_shape)
 
-    # Chunk shape is valid
-    assert isinstance(cfg["chunk_shape"], tuple)
-    assert len(cfg["chunk_shape"]) == len(shape)
+    # If Z exists (… Z Y X), its chunk is 1
+    if len(level0_shape) >= 3:
+        z_idx = len(level0_shape) - 3
+        assert chunk_shape[z_idx] == 1
+
+    # Constructor accepts the preset (no IO performed yet)
+    _ = OMEZarrWriter(store=zarr.storage.MemoryStore(), **cfg)

--- a/bioio_ome_zarr/writers/config.py
+++ b/bioio_ome_zarr/writers/config.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Tuple, Union
+from typing import Any, Dict, List, Tuple, Union
 
 import dask.array as da
 import numpy as np
@@ -6,39 +6,54 @@ import numpy as np
 from .utils import chunk_size_from_memory_target
 
 
+def _xy_pyramid_level_shapes(level0_shape: Tuple[int, ...]) -> List[Tuple[int, ...]]:
+    """
+    Build a 3-level XY pyramid from level-0: halve Y/X at levels 1 and 2.
+    Non-spatial axes are unchanged. Shapes are floored with a minimum of 1.
+    """
+    ndim = len(level0_shape)
+    if ndim < 2:
+        return [tuple(int(x) for x in level0_shape)]
+
+    y_idx = ndim - 2
+    x_idx = ndim - 1
+
+    def downsample(power_of_two: int) -> Tuple[int, ...]:
+        factor = 2**power_of_two
+        mutable = list(level0_shape)
+        mutable[y_idx] = max(1, int(level0_shape[y_idx]) // factor)
+        mutable[x_idx] = max(1, int(level0_shape[x_idx]) // factor)
+        return tuple(int(x) for x in mutable)
+
+    return [
+        tuple(int(x) for x in level0_shape),  # level 0
+        downsample(1),  # level 1 (÷2 on Y/X)
+        downsample(2),  # level 2 (÷4 on Y/X)
+    ]
+
+
 def get_default_config_for_viz(
     data: Union[np.ndarray, da.Array],
 ) -> Dict[str, Any]:
     """
     Visualization preset:
-      - 3-level XY pyramid (0.5, 0.25 on Y/X)
-      - ~16 MiB chunking reused for all levels
-      - Let the writer infer axes, zarr_format, image_name, etc.
+      - 3-level XY pyramid (levels 0/1/2 with Y/X ÷1, ÷2, ÷4)
+      - ~16 MiB chunking suggested from level-0, reused for all levels
+      - Writer infers axes, zarr_format, image_name, etc.
     """
-    shape: Tuple[int, ...] = tuple(data.shape)
+    level0_shape: Tuple[int, ...] = tuple(int(x) for x in data.shape)
     dtype = np.dtype(getattr(data, "dtype", np.uint16))
 
-    # Inline _build_xy_scales
-    ndim = len(shape)
-    if ndim < 2:
-        scale: Tuple[Tuple[float, ...], ...] = tuple()
-    else:
-        scales_list = []
-        for k in (1, 2):  # levels beyond 0
-            vec = [1.0] * ndim
-            vec[-1] = 2.0 ** (-k)  # X
-            vec[-2] = 2.0 ** (-k)  # Y
-            scales_list.append(tuple(vec))
-        scale = tuple(scales_list)
+    level_shapes = _xy_pyramid_level_shapes(level0_shape)
 
+    # One chunk shape applied to all levels (writer will replicate it)
     chunk_shape = tuple(
-        int(x) for x in chunk_size_from_memory_target(shape, dtype, 16 << 20)
+        int(x) for x in chunk_size_from_memory_target(level0_shape, dtype, 16 << 20)
     )
 
     return {
-        "shape": shape,
+        "level_shapes": level_shapes,
         "dtype": dtype,
-        "scale": scale,
         "chunk_shape": chunk_shape,
     }
 
@@ -49,28 +64,27 @@ def get_default_config_for_ml(
     """
     ML preset:
       - Level-0 only (no pyramid)
-      - Z-slice chunking (Z=1) when Z exists; ~16 MiB target otherwise
-      - Writer infers everything else.
+      - Prefer Z-slice chunking (Z=1) when Z exists; else ~16 MiB target
+      - Writer infers remaining fields.
     """
-    shape: Tuple[int, ...] = tuple(data.shape)
+    level0_shape: Tuple[int, ...] = tuple(int(x) for x in data.shape)
     dtype = np.dtype(getattr(data, "dtype", np.uint16))
 
     base_chunk = tuple(
-        int(x) for x in chunk_size_from_memory_target(shape, dtype, 16 << 20)
+        int(x) for x in chunk_size_from_memory_target(level0_shape, dtype, 16 << 20)
     )
 
-    ndim = len(shape)
-    if ndim >= 3:
-        z_idx = ndim - 3
-        tmp = list(base_chunk)
-        tmp[z_idx] = 1
-        chunk_shape = tuple(int(x) for x in tmp)
+    # If we have at least (… Z Y X), set Z chunk to 1
+    if len(level0_shape) >= 3:
+        z_idx = len(level0_shape) - 3
+        chunk_list = list(base_chunk)
+        chunk_list[z_idx] = 1
+        chunk_shape = tuple(int(x) for x in chunk_list)
     else:
         chunk_shape = base_chunk
 
     return {
-        "shape": shape,
+        "level_shapes": [level0_shape],
         "dtype": dtype,
-        "scale": tuple(),  # no extra levels
         "chunk_shape": chunk_shape,
     }


### PR DESCRIPTION
## Descritpion 

Resolves #93. When we updated the scaling to use `level_shapes` instead of `scale` and `shape` this broke the configs but didn't register as a break since we didn't assert that the parameters we are passing out of the config are valid (only that they were the right shape). This PR updates configs for new api, adds tests for valid params, and constructs a writer for each tests case.