### PR TITLE
Feature/improved default chunking

### DIFF
--- a/bioio_ome_zarr/tests/writers/test_chunking.py
+++ b/bioio_ome_zarr/tests/writers/test_chunking.py
@@ -1,0 +1,228 @@
+import numpy as np
+import pytest
+
+from ...writers.utils import (
+    DimSeq,
+    PerLevelDimSeq,
+    multiscale_chunk_size_from_memory_target,
+)
+
+
+def _nbytes(shape: DimSeq, dtype: str = "uint16") -> int:
+    return int(np.prod(shape)) * np.dtype(dtype).itemsize
+
+
+@pytest.mark.parametrize(
+    "level_shapes,dtype,mem_target,expected",
+    [
+        pytest.param(  # 2D YX
+            [(64, 64), (32, 32), (16, 16)],
+            "uint16",
+            16 << 20,
+            [(64, 64), (32, 32), (16, 16)],
+            id="passthrough_2d",
+        ),
+        pytest.param(  # 5D TCZYX
+            [(2, 3, 4, 64, 64), (2, 3, 4, 32, 32), (2, 3, 4, 16, 16)],
+            "uint16",
+            16 << 20,
+            [(2, 3, 4, 64, 64), (2, 3, 4, 32, 32), (2, 3, 4, 16, 16)],
+            id="passthrough_5d",
+        ),
+    ],
+)
+def test_passthrough(
+    level_shapes: PerLevelDimSeq, dtype: str, mem_target: int, expected: PerLevelDimSeq
+) -> None:
+    chunks = multiscale_chunk_size_from_memory_target(level_shapes, dtype, mem_target)
+    assert chunks == expected
+
+
+@pytest.mark.parametrize(
+    "level_shapes,expected",
+    [
+        pytest.param(
+            [(100, 100), (37, 37), (19, 19)],
+            [(100, 100), (37, 37), (19, 19)],
+            id="irregular_downsample",
+        ),
+    ],
+)
+def test_irregular_downsampling(
+    level_shapes: PerLevelDimSeq, expected: PerLevelDimSeq
+) -> None:
+    chunks = multiscale_chunk_size_from_memory_target(level_shapes, "uint16", 16 << 20)
+    assert chunks == expected
+
+
+@pytest.mark.parametrize(
+    "level_shapes,dtype,mem_target,expected",
+    [
+        pytest.param(
+            [(2, 3, 4, 64, 64), (2, 3, 4, 32, 32), (2, 3, 4, 16, 16)],
+            "uint16",
+            8 << 10,  # 8 KiB = bytes((1,1,1,64,64))
+            [
+                (1, 1, 1, 64, 64),
+                (1, 1, 4, 32, 32),
+                (1, 3, 4, 16, 16),
+            ],
+            id="budget_progression_5d_8KiB_Z_only",
+        ),
+        pytest.param(
+            [(2, 3, 4, 64, 64), (2, 3, 4, 32, 32), (2, 3, 4, 16, 16)],
+            "uint16",
+            32 << 10,  # 32 KiB = bytes((1,1,4,64,64)) → Z full
+            [
+                (1, 1, 4, 64, 64),
+                (1, 3, 4, 32, 32),
+                (2, 3, 4, 16, 16),
+            ],
+            id="budget_progression_5d_32KiB_Z_full_then_C_then_T",
+        ),
+        pytest.param(
+            [(2, 3, 4, 64, 64), (2, 3, 4, 32, 32), (2, 3, 4, 16, 16)],
+            "uint16",
+            64 << 10,  # 64 KiB → C grows at L0, T grows at L1
+            [
+                (1, 2, 4, 64, 64),
+                (2, 3, 4, 32, 32),
+                (2, 3, 4, 16, 16),
+            ],
+            id="budget_progression_5d_64KiB_C_growth",
+        ),
+        pytest.param(
+            [(2, 3, 4, 64, 64), (2, 3, 4, 32, 32), (2, 3, 4, 16, 16)],
+            "uint16",
+            192 << 10,  # 192 KiB ≈ full
+            [
+                (2, 3, 4, 64, 64),
+                (2, 3, 4, 32, 32),
+                (2, 3, 4, 16, 16),
+            ],
+            id="budget_progression_5d_full",
+        ),
+    ],
+)
+def test_budget_progression(
+    level_shapes: PerLevelDimSeq, dtype: str, mem_target: int, expected: PerLevelDimSeq
+) -> None:
+    chunks = multiscale_chunk_size_from_memory_target(level_shapes, dtype, mem_target)
+    assert chunks == expected
+    for ch in chunks:
+        assert _nbytes(ch, dtype) <= mem_target
+
+
+@pytest.mark.parametrize(
+    "level_shapes,dtype,memory_target,expected",
+    [
+        # compact 2–3 level coverage
+        pytest.param(
+            [(1024, 1024), (512, 512), (256, 256)],
+            "uint16",
+            1 << 20,  # 1 MiB
+            [(512, 1024), (512, 512), (256, 256)],
+            id="small_2d_yx",
+        ),
+        pytest.param(
+            [(32, 1024, 1024), (32, 512, 512)],
+            "float32",
+            4 << 20,  # 4 MiB
+            [(1, 1024, 1024), (4, 512, 512)],
+            id="small_3d_zyx",
+        ),
+        pytest.param(
+            [(3, 32, 1024, 1024), (3, 32, 512, 512)],
+            "uint16",
+            8 << 20,  # 8 MiB
+            [(1, 4, 1024, 1024), (1, 16, 512, 512)],
+            id="small_4d_czyx",
+        ),
+        pytest.param(
+            [(10, 2, 32, 1024, 1024), (10, 2, 32, 512, 512)],
+            "uint16",
+            16 << 20,  # 16 MiB
+            [(1, 1, 8, 1024, 1024), (1, 1, 32, 512, 512)],
+            id="small_5d_tczyx",
+        ),
+        # very large shapes, 5 levels
+        pytest.param(
+            [(8192, 8192), (4096, 4096), (2048, 2048), (1024, 1024), (512, 512)],
+            "uint16",
+            8 << 20,  # 8 MiB
+            [(512, 8192), (1024, 4096), (2048, 2048), (1024, 1024), (512, 512)],
+            id="large_2d_yx_5levels",
+        ),
+        pytest.param(
+            [
+                (64, 4096, 4096),
+                (64, 2048, 2048),
+                (64, 1024, 1024),
+                (64, 512, 512),
+                (64, 256, 256),
+            ],
+            "uint16",
+            8 << 20,  # 8 MiB
+            [
+                (1, 1024, 4096),
+                (1, 2048, 2048),
+                (4, 1024, 1024),
+                (16, 512, 512),
+                (64, 256, 256),
+            ],
+            id="large_3d_zyx_5levels",
+        ),
+        pytest.param(
+            [
+                (8, 64, 4096, 4096),
+                (8, 64, 2048, 2048),
+                (8, 64, 1024, 1024),
+                (8, 64, 512, 512),
+                (8, 64, 256, 256),
+            ],
+            "uint16",
+            16 << 20,  # 16 MiB
+            [
+                (1, 1, 2048, 4096),
+                (1, 2, 2048, 2048),
+                (1, 8, 1024, 1024),
+                (1, 32, 512, 512),
+                (2, 64, 256, 256),
+            ],
+            id="large_4d_czyx_5levels",
+        ),
+        pytest.param(
+            [
+                (16, 4, 64, 2048, 2048),
+                (16, 4, 64, 1024, 1024),
+                (16, 4, 64, 512, 512),
+                (16, 4, 64, 256, 256),
+                (16, 4, 64, 128, 128),
+            ],
+            "uint16",
+            16 << 20,  # 16 MiB
+            [
+                (1, 1, 2, 2048, 2048),
+                (1, 1, 8, 1024, 1024),
+                (1, 1, 32, 512, 512),
+                (1, 2, 64, 256, 256),
+                (2, 4, 64, 128, 128),
+            ],
+            id="large_5d_tczyx_5levels",
+        ),
+    ],
+)
+def test_multiscale_chunk_size_from_memory_target(
+    level_shapes: PerLevelDimSeq,
+    dtype: str,
+    memory_target: int,
+    expected: PerLevelDimSeq,
+) -> None:
+    chunks = multiscale_chunk_size_from_memory_target(
+        level_shapes, dtype, memory_target
+    )
+    assert chunks == expected
+
+    for lvl, (shape, chunk) in enumerate(zip(level_shapes, chunks)):
+        assert all(1 <= c <= s for c, s in zip(chunk, shape)), f"[L{lvl}] bounds"
+        assert _nbytes(chunk, dtype) <= memory_target, f"[L{lvl}] bytes"

--- a/bioio_ome_zarr/writers/__init__.py
+++ b/bioio_ome_zarr/writers/__init__.py
@@ -16,6 +16,7 @@ from .utils import (
     compute_level_chunk_sizes_zslice,
     compute_level_shapes,
     get_scale_ratio,
+    multiscale_chunk_size_from_memory_target,
     resize,
 )
 
@@ -30,6 +31,7 @@ __all__ = [
     "add_zarr_level",
     "build_ngff_metadata",
     "chunk_size_from_memory_target",
+    "multiscale_chunk_size_from_memory_target",
     "compute_level_chunk_sizes_zslice",
     "compute_level_shapes",
     "resize",

--- a/bioio_ome_zarr/writers/ome_zarr_writer.py
+++ b/bioio_ome_zarr/writers/ome_zarr_writer.py
@@ -278,7 +278,7 @@ class OMEZarrWriter:
         else:
             computed_chunk_shapes = multiscale_chunk_size_from_memory_target(
                 self.level_shapes,
-                str(self.dtype),
+                self.dtype,
                 16 << 20,  # ~16 MiB target
             )
             # normalize to List[Tuple[int, ...]]

--- a/bioio_ome_zarr/writers/ome_zarr_writer.py
+++ b/bioio_ome_zarr/writers/ome_zarr_writer.py
@@ -189,7 +189,7 @@ class OMEZarrWriter:
             Either a single chunk shape (applied to all levels),
             e.g. ``(1,1,16,256,256)``, or per-level chunk shapes,
             e.g. ``[(1,1,16,256,256), (1,1,16,128,128), ...]``. If ``None``,
-            a suggested ≈16 MiB chunk is derived per level;
+            a suggested ≈16 MiB chunk is derived per level.
         shard_shape : Optional[Union[Sequence[int], Sequence[Sequence[int]]]]
             **Zarr v3 only.** Either:
               - a single N-dim sequence applied to all levels, or

--- a/bioio_ome_zarr/writers/ome_zarr_writer_v2.py
+++ b/bioio_ome_zarr/writers/ome_zarr_writer_v2.py
@@ -179,7 +179,7 @@ class OMEZarrWriter:
                 region=(slice(k + toffset, k + toffset + 1),),
             )
         for j in range(1, len(self.levels)):
-            nextshape = (end_t - start_t,) + self.levels[j].shape[1:]
+            nextshape = (end_t - start_t,) + tuple(self.levels[j].shape[1:])
             data_tczyx = resize(data_tczyx, nextshape, order=0).astype(dtype)
             for k in range(start_t, end_t):
                 subset = data_tczyx[[k - start_t]]
@@ -394,7 +394,7 @@ class OMEZarrWriter:
         metadata_dict = _pop_metadata_optionals(metadata_dict)
 
         # get the total shape as dict:
-        shapedict = dim_tuple_to_dict(self.levels[0].shape)
+        shapedict = dim_tuple_to_dict(tuple(self.levels[0].shape))
 
         # add the omero data
         ome_json = build_ome(

--- a/bioio_ome_zarr/writers/utils.py
+++ b/bioio_ome_zarr/writers/utils.py
@@ -307,6 +307,11 @@ def multiscale_chunk_size_from_memory_target(
     Compute per-level chunk shapes under a fixed byte budget, **prioritizing the
     highest-index axis first** (i.e., grow X, then Y, then Z, ... moving left).
 
+    Note
+    -----
+    These chunk sizes represent an **in-memory target only** and do not account
+    for compression.
+
     Returns
     -------
     list[Sequence[int]]

--- a/bioio_ome_zarr/writers/utils.py
+++ b/bioio_ome_zarr/writers/utils.py
@@ -1,3 +1,4 @@
+import math
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, List, Optional, Sequence, Tuple, Union, cast
@@ -12,13 +13,17 @@ from zarr.storage import LocalStore
 
 from bioio_ome_zarr.reader import Reader
 
+DimSeq = Sequence[int]
+PerLevelDimSeq = Sequence[DimSeq]
 DimTuple = Tuple[int, ...]
 
 
 @dataclass
 class ZarrLevel:
-    shape: DimTuple
-    chunk_size: DimTuple
+    """Descriptor for a Zarr multiscale level."""
+
+    shape: DimSeq
+    chunk_size: DimSeq
     dtype: np.dtype
     zarray: zarr.Array
 
@@ -115,10 +120,10 @@ def compute_level_shapes(
     return shapes
 
 
-# This is used as the default for V2 instead of 16mb chunk default
+# LEGACY (Remove with V2 writer)
 def compute_level_chunk_sizes_zslice(
     level_shapes: List[Tuple[int, ...]],
-) -> List[DimTuple]:
+) -> List[DimSeq]:
     """
     Compute Z-slice–based chunk sizes for a multiscale pyramid.
     Parameters
@@ -128,12 +133,12 @@ def compute_level_chunk_sizes_zslice(
         but expecting at least 5 dimensions for TCZYX indexing.
     Returns
     -------
-    List[DimTuple]
+    List[DimSeq]
         Chunk sizes as 5-tuples (T, C, Z, Y, X).
     """
 
     ndim = len(level_shapes[0])
-    result: List[DimTuple] = []
+    result: List[DimSeq] = []
 
     if ndim == 5:
         # Legacy exact behavior
@@ -143,7 +148,7 @@ def compute_level_chunk_sizes_zslice(
             curr_shape = level_shapes[i]
             scale = tuple(prev_shape[j] / curr_shape[j] for j in range(5))
             p = result[i - 1]
-            new_chunk: DimTuple = (
+            new_chunk: DimSeq = (
                 1,
                 1,
                 int(scale[4] * scale[3] * p[2]),
@@ -177,6 +182,7 @@ def compute_level_chunk_sizes_zslice(
     return result
 
 
+# LEGACY (Remove with V3 writer)
 def chunk_size_from_memory_target(
     shape: Tuple[int, ...],
     dtype: Union[str, np.dtype],
@@ -288,3 +294,50 @@ def add_zarr_level(
     print(
         f"Added level {new_idx}: shape={new_shape}, chunks={chunks}, scale={new_scale}"
     )
+
+
+def multiscale_chunk_size_from_memory_target(
+    level_shapes: Sequence[Sequence[int]],
+    dtype: Union[str, np.dtype],
+    memory_target: int,
+) -> List[Sequence[int]]:
+    """
+    Compute per-level chunk shapes under a fixed byte budget, **prioritizing the
+    highest-index axis first** (i.e., grow X, then Y, then Z, ... moving left).
+
+    Returns
+    -------
+    list[Sequence[int]]
+        Per-level chunk shapes (same ndim/order as the input).
+    """
+    if not level_shapes:
+        raise ValueError("level_shapes cannot be empty")
+
+    # Validation
+    for i, shp in enumerate(level_shapes):
+        if len(shp) < 2:
+            raise ValueError(f"level_shapes[{i}] must have ndim >= 2, got {len(shp)}")
+        if any(int(d) < 1 for d in shp):
+            raise ValueError(f"level_shapes[{i}] has non-positive dimension(s): {shp}")
+
+    itemsize = np.dtype(dtype).itemsize
+    if memory_target < itemsize:
+        raise ValueError(f"memory_target {memory_target} < dtype size {itemsize}")
+
+    budget_elems = max(1, memory_target // itemsize)
+
+    out: List[Sequence[int]] = []
+    for shp in level_shapes:
+        # Start with all-ones, grow from rightmost axis leftward
+        chunk = [1] * len(shp)
+        for axis in reversed(range(len(shp))):
+            used = math.prod(chunk)
+            if used >= budget_elems:
+                # No room left; keep remaining (left) axes at 1
+                break
+            max_here = budget_elems // used
+            # Cap by the level dimension and ensure at least 1
+            chunk[axis] = max(1, min(int(shp[axis]), int(max_here)))
+        out.append(tuple(chunk))
+
+    return out

--- a/bioio_ome_zarr/writers/utils.py
+++ b/bioio_ome_zarr/writers/utils.py
@@ -15,6 +15,8 @@ from bioio_ome_zarr.reader import Reader
 
 DimSeq = Sequence[int]
 PerLevelDimSeq = Sequence[DimSeq]
+
+# LEGACY (Remove with V2 writer)
 DimTuple = Tuple[int, ...]
 
 


### PR DESCRIPTION
## Description 

The purpose of this PR is to resolve #89 and #78. We want to nail down our default chunking policy since it'll be used very heavily. This PR universalizes the V2/V3 chunking using these policies.

#### 16 mbs default per level
This means each level will have different shaped chunks but the chunks will be the same memory size

#### Prioritize in max size in X → Y → Z → C → T order
I think of it as a series of cups filling, first X will fill up to its max, then Y, then Z etc. where the water is the max memory for a single chunk.

Example 
```
level_shapes = [(8, 64, 4096, 4096),(8, 64, 2048, 2048),(8, 64, 1024, 1024),(8, 64, 512, 512),(8, 64, 256, 256), ],
chunk_shapes = [(1, 1, 2048, 4096),(1, 2, 2048, 2048),(1, 8, 1024, 1024),(1, 32, 512, 512),(2, 64, 256, 256),],
```
