### PR TITLE
admin/remove-unnecessary-warning

### DIFF
--- a/bioio_ome_zarr/reader.py
+++ b/bioio_ome_zarr/reader.py
@@ -273,12 +273,6 @@ class Reader(reader.Reader):
             The elementwise product of the global and dataset-specific scales.
         """
         multiscales = self._multiscales_metadata[self._current_scene_index]
-
-        if "coordinateTransformations" not in multiscales:
-            log.warning(
-                "No overall 'coordinateTransformations' found; "
-                "defaulting overall scale to 1.0 for each dim"
-            )
         overall_scale = multiscales.get(
             "coordinateTransformations", [{"scale": [1.0] * len(dims)}]
         )[0]["scale"]


### PR DESCRIPTION
## Description 

The purpose of this PR is to resolve #65  and remove an unnecessary warning about `CoordinateTransformations`. The presence of this transformation is actually less common and marked as optional by the spec, so it doesn't make sense to warn users each time about an edge case thing.