### PR TITLE
admin/pin-dask

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "bioio-base>=1.4.0",
-    "dask<2025.11.0", # Pinning due to warning moving to error level
+    "dask!=2025.11.0",
     "fsspec[http]>=2022.8.0",
     "s3fs>=2023.9.0",
     "scikit-image!=0.23.0",


### PR DESCRIPTION
## Description 

The purpose of this PR is to pin dask and fix our failing unit tests. `Dask==2025.11.0` adds a warning that is at error level about writing chunks that are not divisions of the original shape. I think that it should just be at warning level and we should be good to go if dask fixes it. Otherwise we have to do some reconsidering about how we are doing chunking.

Adresses #112 I opened https://github.com/dask/dask/issues/12159 as well