### PR TITLE
Add downsample_z flag to get_default_config_for_viz for 3D viewer support

### DIFF
--- a/bioio_ome_zarr/tests/writers/test_config.py
+++ b/bioio_ome_zarr/tests/writers/test_config.py
@@ -18,32 +18,46 @@ def _allowed_writer_keys() -> List[str]:
     return [name for name in sig.parameters if name != "self"]
 
 
-@pytest.mark.parametrize("level0_shape", [(1, 1, 4, 16, 8), (4, 4)])
-def test_viz_preset_cfg(level0_shape: Tuple[int, ...]) -> None:
+@pytest.mark.parametrize(
+    "level0_shape, downsample_z",
+    [
+        ((1, 1, 4, 16, 8), False),  # 5D, XY-only (default)
+        ((4, 4), False),  # 2D, XY-only
+        ((1, 1, 4, 16, 8), True),  # 5D, XYZ
+        ((1, 4, 16, 8), True),  # 4D, XYZ
+    ],
+)
+def test_viz_preset_cfg(level0_shape: Tuple[int, ...], downsample_z: bool) -> None:
     data = np.zeros(level0_shape, dtype=np.uint8)
-    cfg = get_default_config_for_viz(data)
+    cfg = get_default_config_for_viz(data, downsample_z=downsample_z)
 
     # API valid
     assert set(cfg.keys()) == {"level_shapes", "dtype", "chunk_shape"}
     assert set(cfg.keys()).issubset(set(_allowed_writer_keys()))
 
-    # Basic semantics
     assert cfg["dtype"] == data.dtype
     level_shapes = cfg["level_shapes"]
     assert len(level_shapes) == 3
     assert tuple(level_shapes[0]) == tuple(level0_shape)
 
-    # XY pyramid: halve and quarter Y/X (floor)
+    # Determine which trailing axes are downsampled
     ndim = len(level0_shape)
-    y_idx, x_idx = ndim - 2, ndim - 1
+    n_spatial = 3 if (downsample_z and ndim >= 3) else 2
+    spatial_indices = list(range(ndim - n_spatial, ndim))
+
     expected_l1 = list(level0_shape)
-    expected_l1[y_idx] = max(1, level0_shape[y_idx] // 2)
-    expected_l1[x_idx] = max(1, level0_shape[x_idx] // 2)
     expected_l2 = list(level0_shape)
-    expected_l2[y_idx] = max(1, level0_shape[y_idx] // 4)
-    expected_l2[x_idx] = max(1, level0_shape[x_idx] // 4)
+    for i in spatial_indices:
+        expected_l1[i] = max(1, level0_shape[i] // 2)
+        expected_l2[i] = max(1, level0_shape[i] // 4)
+
     assert tuple(level_shapes[1]) == tuple(expected_l1)
     assert tuple(level_shapes[2]) == tuple(expected_l2)
+
+    # Non-spatial axes are unchanged across all levels
+    non_spatial_end = ndim - n_spatial
+    for shapes in level_shapes:
+        assert tuple(shapes[:non_spatial_end]) == tuple(level0_shape[:non_spatial_end])
 
     # Chunk shape
     chunk_shape = cfg["chunk_shape"]

--- a/bioio_ome_zarr/writers/config.py
+++ b/bioio_ome_zarr/writers/config.py
@@ -5,52 +5,57 @@ import numpy as np
 
 from .utils import multiscale_chunk_size_from_memory_target
 
+_CHUNK_TARGET_BYTES = 16 << 20  # 16 MiB
 
-def _xy_pyramid_level_shapes(level0_shape: Tuple[int, ...]) -> List[Tuple[int, ...]]:
+
+def _pyramid_level_shapes(
+    level0_shape: Tuple[int, ...], n_spatial: int
+) -> List[Tuple[int, ...]]:
     """
-    Build a 3-level XY pyramid from level-0: halve Y/X at levels 1 and 2.
+    Build a 3-level pyramid from level-0, halving the last n_spatial axes at each level.
     Non-spatial axes are unchanged. Shapes are floored with a minimum of 1.
+    If ndim < n_spatial, all axes are treated as spatial.
     """
     ndim = len(level0_shape)
-    if ndim < 2:
-        return [tuple(int(x) for x in level0_shape)]
-
-    y_idx = ndim - 2
-    x_idx = ndim - 1
+    spatial_indices = list(range(ndim - min(n_spatial, ndim), ndim))
 
     def downsample(power_of_two: int) -> Tuple[int, ...]:
         factor = 2**power_of_two
         mutable = list(level0_shape)
-        mutable[y_idx] = max(1, int(level0_shape[y_idx]) // factor)
-        mutable[x_idx] = max(1, int(level0_shape[x_idx]) // factor)
+        for i in spatial_indices:
+            mutable[i] = max(1, int(level0_shape[i]) // factor)
         return tuple(int(x) for x in mutable)
 
     return [
         tuple(int(x) for x in level0_shape),  # level 0
-        downsample(1),  # level 1 (÷2 on Y/X)
-        downsample(2),  # level 2 (÷4 on Y/X)
+        downsample(1),  # level 1 (÷2)
+        downsample(2),  # level 2 (÷4)
     ]
 
 
 def get_default_config_for_viz(
     data: Union[np.ndarray, da.Array],
+    downsample_z: bool = False,
 ) -> Dict[str, Any]:
     """
     Visualization preset:
-      - 3-level XY pyramid (levels 0/1/2 with Y/X ÷1, ÷2, ÷4)
+      - 3-level pyramid (levels 0/1/2 with spatial axes ÷1, ÷2, ÷4)
+      - downsample_z=False (default): halve Y/X only (2D viewers, e.g. napari)
+      - downsample_z=True: halve Z/Y/X equally (3D viewers, e.g. Neuroglancer)
       - ~16 MiB chunking suggested from level-0, reused for all levels
       - Writer infers axes, zarr_format, image_name, etc.
     """
     level0_shape: Tuple[int, ...] = tuple(int(x) for x in data.shape)
     dtype = np.dtype(getattr(data, "dtype", np.uint16))
 
-    level_shapes = _xy_pyramid_level_shapes(level0_shape)
+    n_spatial = 3 if downsample_z else 2
+    level_shapes = _pyramid_level_shapes(level0_shape, n_spatial)
 
     # One chunk shape applied to all levels (writer will replicate it)
     chunk_shape = tuple(
         int(x)
         for x in multiscale_chunk_size_from_memory_target(
-            [level0_shape], dtype, 16 << 20
+            [level0_shape], dtype, _CHUNK_TARGET_BYTES
         )[0]
     )
 
@@ -76,7 +81,7 @@ def get_default_config_for_ml(
     base_chunk = tuple(
         int(x)
         for x in multiscale_chunk_size_from_memory_target(
-            [level0_shape], dtype, 16 << 20
+            [level0_shape], dtype, _CHUNK_TARGET_BYTES
         )[0]
     )
 

--- a/bioio_ome_zarr/writers/config.py
+++ b/bioio_ome_zarr/writers/config.py
@@ -40,8 +40,8 @@ def get_default_config_for_viz(
     """
     Visualization preset:
       - 3-level pyramid (levels 0/1/2 with spatial axes ÷1, ÷2, ÷4)
-      - downsample_z=False (default): halve Y/X only (2D viewers, e.g. napari)
-      - downsample_z=True: halve Z/Y/X equally (3D viewers, e.g. Neuroglancer)
+      - downsample_z=False (default): halve Y/X only (2D viewers)
+      - downsample_z=True: halve Z/Y/X equally (3D viewers)
       - ~16 MiB chunking suggested from level-0, reused for all levels
       - Writer infers axes, zarr_format, image_name, etc.
     """


### PR DESCRIPTION
## Summary

Closes #138

- Add `downsample_z: bool = False` parameter to `get_default_config_for_viz`; when `True`, Z/Y/X are all halved equally at each pyramid level (intended for isotropic 3D viewers like Neuroglancer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)