### PR TITLE
Pin pydantic<2.13 to fix CI failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ test = [
   "pytest>=5.4.3",
   "pytest-cov>=2.9.0",
   "pytest-raises>=0.11",
-  "ome-zarr-models>=1.4",
+  "ome-zarr-models>=1.4,<1.6",
 ]
 
 # entry points

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,8 @@ test = [
   "pytest>=5.4.3",
   "pytest-cov>=2.9.0",
   "pytest-raises>=0.11",
-  "ome-zarr-models>=1.4,<1.6",
+  "ome-zarr-models>=1.4",
+  "pydantic<2.13",
 ]
 
 # entry points


### PR DESCRIPTION
## Summary

- Pins `pydantic<2.13` in test dependencies to unblock CI

Closes #140

## Context

Bisection shows pydantic 2.13 is the culprit — it tightened model completeness checks, causing `ome-zarr-models`' `Image` model to raise `PydanticUserError` when validating zarr v2 stores. Both ome-zarr-models 1.5 and 1.6 are affected; this is not a regression in ome-zarr-models itself. A bug report has been filed upstream. https://github.com/ome-zarr-models/ome-zarr-models-py/issues/417

## Test plan

- [x] CI passes with the pin in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)