### PR TITLE
Bugfix: Infer axis types from names instead of canonical position

### DIFF
--- a/bioio_ome_zarr/tests/writers/test_metadata.py
+++ b/bioio_ome_zarr/tests/writers/test_metadata.py
@@ -1,0 +1,40 @@
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from bioio_ome_zarr.writers.metadata import Axes
+
+
+@pytest.mark.parametrize(
+    "ndim, kwargs, expected_types",
+    [
+        # No names: canonical suffix defaults are preserved.
+        (5, {}, ["time", "channel", "space", "space", "space"]),
+        (3, {}, ["space", "space", "space"]),
+        # Names given: type is inferred per-name, independent of order.
+        (
+            5,
+            {"names": ["t", "c", "z", "y", "x"]},
+            ["time", "channel", "space", "space", "space"],
+        ),
+        (4, {"names": ["c", "z", "y", "x"]}, ["channel", "space", "space", "space"]),
+        (3, {"names": ["t", "y", "x"]}, ["time", "space", "space"]),
+        # Out-of-order ZCYX (the regression): z->space and c->channel, not the
+        # canonical-order positional default (which gave z->channel, c->space).
+        (4, {"names": ["z", "c", "y", "x"]}, ["space", "channel", "space", "space"]),
+        # Inference is case-insensitive.
+        (4, {"names": ["Z", "C", "Y", "X"]}, ["space", "channel", "space", "space"]),
+        # Explicit types are honored verbatim.
+        (2, {"names": ["y", "x"], "types": ["custom", "space"]}, ["custom", "space"]),
+        # Unknown/custom axis name -> untyped (None); NGFF permits this.
+        (3, {"names": ["q", "y", "x"]}, [None, "space", "space"]),
+    ],
+)
+def test_axes_types(
+    ndim: int, kwargs: Dict[str, Any], expected_types: List[Optional[str]]
+) -> None:
+    ax = Axes(ndim=ndim, **kwargs)
+    assert ax.types == expected_types
+    meta = ax.to_metadata()
+    assert [d.get("type") for d in meta] == expected_types
+    assert all(("type" in d) == (t is not None) for d, t in zip(meta, expected_types))

--- a/bioio_ome_zarr/writers/metadata.py
+++ b/bioio_ome_zarr/writers/metadata.py
@@ -55,8 +55,10 @@ class Axes:
         Number of dimensions in the image data.
     names : List[str]
         Names of each axis (e.g., ["t", "c", "z", "y", "x"]).
-    types : List[str]
+    types : List[Optional[str]]
         NGFF axis types for each axis (e.g., "time", "channel", "space").
+        ``None`` for an unrecognized (custom) axis, which is rendered without
+        a ``type`` key.
     units : List[Optional[str]]
         Physical units for each axis, if any (e.g., "micrometer").
     scales : List[float]
@@ -69,6 +71,20 @@ class Axes:
     DEFAULT_TYPES: List[str] = ["time", "channel", "space", "space", "space"]
     DEFAULT_UNITS: List[Optional[str]] = [None, None, None, None, None]
     DEFAULT_SCALES: List[float] = [1.0, 1.0, 1.0, 1.0, 1.0]
+
+    # NGFF axis type for each recognized axis name. Used to infer types.
+    NAME_TO_TYPE: Dict[str, str] = {
+        "t": "time",
+        "c": "channel",
+        "z": "space",
+        "y": "space",
+        "x": "space",
+    }
+
+    @classmethod
+    def _infer_type(cls, name: str) -> Optional[str]:
+        """NGFF type for an axis name, or ``None`` for an unrecognized."""
+        return cls.NAME_TO_TYPE.get(name.lower())
 
     def __init__(
         self,
@@ -84,9 +100,11 @@ class Axes:
         self.names = list(
             names[-ndim:] if names is not None else self.DEFAULT_NAMES[-ndim:]
         )
-        self.types = list(
-            types[-ndim:] if types is not None else self.DEFAULT_TYPES[-ndim:]
-        )
+        self.types: List[Optional[str]]
+        if types is not None:
+            self.types = [t for t in types[-ndim:]]
+        else:
+            self.types = [self._infer_type(n) for n in self.names]
         self.units = list(
             units[-ndim:] if units is not None else self.DEFAULT_UNITS[-ndim:]
         )
@@ -108,7 +126,9 @@ class Axes:
         """Return NGFF-style axis dicts with keys: name, type, and optional unit."""
         out: List[Dict[str, Any]] = []
         for n, t, u in zip(self.names, self.types, self.units):
-            d: Dict[str, Any] = {"name": n, "type": t}
+            d: Dict[str, Any] = {"name": n}
+            if t is not None:
+                d["type"] = t
             if u is not None:
                 d["unit"] = u
             out.append(d)


### PR DESCRIPTION
## What

`Axes` defaulted axis **types** by slicing `DEFAULT_TYPES` against the canonical `TCZYX` order, ignoring the axis **names** it was given. Callers passing out-of-order `axes_names` (e.g. a native `ZCYX` reader order) with `axes_types=None` got types assigned to the wrong axes:

```python
Axes(ndim=4, names=["z", "c", "y", "x"]).types
# before: ['channel', 'space', 'space', 'space']   # z->channel, c->space (wrong)
# after:  ['space', 'channel', 'space', 'space']    # z->space, c->channel
```

## Change

- Infer each axis type from its **name** (`t->time`, `c->channel`, `z/y/x->space`) when `types` isn't provided, via a `NAME_TO_TYPE` map — independent of axis order.
- Unrecognized/custom axis names infer `None` and render **without** a `type` key (NGFF permits axes without a core type), rather than guessing or raising.
- Explicit `axes_types` and the canonical no-names default are unchanged.

## Tests

Added `tests/writers/test_metadata.py` — one parameterized `test_axes_types` covering canonical defaults, per-name inference, out-of-order `ZCYX`, case-insensitivity, explicit types, and unknown→untyped (plus the `to_metadata` rendering: a `type` key appears iff the axis has a non-`None` type). Full writer suite: 103 passed.

## Context

Surfaced from a downstream conversion bug (bioio-devs/bioio-conversion#53): a native `ZCYX` nd2 converted to a store with `z: channel`, `c: space`. The reader and pyramid were correct; only the axis types were wrong, traced to this positional default.

Closes #150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)