### PR TITLE
feature: Add attribute addition to writer

### DIFF
--- a/bioio_ome_zarr/tests/writers/test_ome_zarr_writer.py
+++ b/bioio_ome_zarr/tests/writers/test_ome_zarr_writer.py
@@ -1,7 +1,7 @@
 import json
 import multiprocessing as mp
 import pathlib
-from typing import Any, Dict, List, Literal, Optional, Tuple, Union, cast
+from typing import Any, Dict, List, Literal, Optional, Tuple, cast
 
 import dask.array as da
 import numpy as np
@@ -12,6 +12,7 @@ from ngff_zarr.validate import validate as ngff_validate
 
 from bioio_ome_zarr import Reader
 from bioio_ome_zarr.writers import Channel, OMEZarrWriter
+from bioio_ome_zarr.writers.ome_zarr_writer import AttributesSpec
 
 from ..conftest import LOCAL_RESOURCES_DIR
 
@@ -60,7 +61,7 @@ def assert_valid_ome_zarr(
 def test_preview_metadata_merges_attributes(
     tmp_path: pathlib.Path,
     zarr_format: int,
-    attributes: Union[Dict[str, Any], List[Dict[str, Any]]],
+    attributes: AttributesSpec,
     expected: dict,
 ) -> None:
     writer = OMEZarrWriter(

--- a/bioio_ome_zarr/tests/writers/test_ome_zarr_writer.py
+++ b/bioio_ome_zarr/tests/writers/test_ome_zarr_writer.py
@@ -11,8 +11,7 @@ import zarr
 from ngff_zarr.validate import validate as ngff_validate
 
 from bioio_ome_zarr import Reader
-from bioio_ome_zarr.writers import Channel, OMEZarrWriter
-from bioio_ome_zarr.writers.ome_zarr_writer import AttributesSpec
+from bioio_ome_zarr.writers import AttributesSpec, Channel, OMEZarrWriter
 
 from ..conftest import LOCAL_RESOURCES_DIR
 

--- a/bioio_ome_zarr/tests/writers/test_ome_zarr_writer.py
+++ b/bioio_ome_zarr/tests/writers/test_ome_zarr_writer.py
@@ -1,7 +1,7 @@
 import json
 import multiprocessing as mp
 import pathlib
-from typing import Any, Dict, List, Literal, Optional, Tuple, cast
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union, cast
 
 import dask.array as da
 import numpy as np
@@ -43,6 +43,36 @@ def assert_valid_ome_zarr(
     else:
         ngff_validate(attrs, version="0.5", model="image", strict=False)
         assert "ome" in attrs and "multiscales" in attrs["ome"]
+
+
+@pytest.mark.parametrize("zarr_format", [2, 3], ids=["v2", "v3"])
+@pytest.mark.parametrize(
+    "attributes, expected",
+    [
+        ({"bioio": {"version": "1.2.3"}}, {"bioio": {"version": "1.2.3"}}),
+        (
+            [{"a": 1, "shared": "first"}, {"b": 2, "shared": "second"}],
+            {"a": 1, "b": 2, "shared": "second"},
+        ),
+    ],
+    ids=["dict", "list"],
+)
+def test_preview_metadata_merges_attributes(
+    tmp_path: pathlib.Path,
+    zarr_format: int,
+    attributes: Union[Dict[str, Any], List[Dict[str, Any]]],
+    expected: dict,
+) -> None:
+    writer = OMEZarrWriter(
+        store=str(tmp_path / "attrs.zarr"),
+        level_shapes=[(1, 1, 1, 4, 4)],
+        dtype=np.uint8,
+        zarr_format=cast(Literal[2, 3], zarr_format),
+        attributes=attributes,
+    )
+    md = writer.preview_metadata()
+    assert {key: md[key] for key in expected} == expected
+    assert ("multiscales" if zarr_format == 2 else "ome") in md
 
 
 @pytest.mark.parametrize(

--- a/bioio_ome_zarr/writers/__init__.py
+++ b/bioio_ome_zarr/writers/__init__.py
@@ -3,7 +3,7 @@ from .config import (
     get_default_config_for_viz,
 )
 from .metadata import Axes, Channel, MetadataParams, build_ngff_metadata
-from .ome_zarr_writer import OMEZarrWriter
+from .ome_zarr_writer import AttributesSpec, OMEZarrWriter
 from .utils import (
     add_zarr_level,
     edit_metadata,
@@ -12,6 +12,7 @@ from .utils import (
 )
 
 __all__ = [
+    "AttributesSpec",
     "Axes",
     "Channel",
     "MetadataParams",

--- a/bioio_ome_zarr/writers/ome_zarr_writer.py
+++ b/bioio_ome_zarr/writers/ome_zarr_writer.py
@@ -15,6 +15,7 @@ from .utils import (
     resize,
 )
 
+AttributesSpec = Union[Dict[str, Any], List[Dict[str, Any]]]
 MultiResolutionShapeSpec = Union[DimSeq, PerLevelDimSeq]
 
 
@@ -171,6 +172,7 @@ class OMEZarrWriter:
         axes_types: Optional[List[str]] = None,
         axes_units: Optional[List[Optional[str]]] = None,
         physical_pixel_size: Optional[List[float]] = None,
+        attributes: Optional[AttributesSpec] = None,
     ) -> None:
         """
         Initialize the writer and capture core configuration. Arrays and
@@ -217,6 +219,8 @@ class OMEZarrWriter:
             Physical units for each axis.
         physical_pixel_size : Optional[List[float]]
             Physical scale at level 0 for each axis.
+        attributes : Optional[Union[Dict[str, Any], List[Dict[str, Any]]]]
+            Extra key/values merged into the root group's attributes.
         """
         if len(level_shapes) == 0:
             raise ValueError("level_shapes cannot be empty")
@@ -315,6 +319,7 @@ class OMEZarrWriter:
         self.rdefs = rdefs
         self.creator_info = creator_info
         self.root_transform = root_transform
+        self.attributes = attributes
 
         # Handles & state
         self.root: Optional[zarr.Group]
@@ -341,10 +346,23 @@ class OMEZarrWriter:
             root_transform=self.root_transform,
             dataset_scales=self.dataset_scales,
         )
-        return build_ngff_metadata(
+        md = build_ngff_metadata(
             zarr_format=self.zarr_format,
             params=params,
         )
+
+        # Caller-supplied attributes keys
+        if self.attributes:
+            mappings = (
+                [self.attributes]
+                if isinstance(self.attributes, dict)
+                else self.attributes
+            )
+            for mapping in mappings:
+                if mapping:
+                    md.update(mapping)
+
+        return md
 
     def initialize(self) -> None:
         """
@@ -728,13 +746,7 @@ class OMEZarrWriter:
         )
 
     def _write_metadata(self) -> None:
-        """Persist NGFF metadata to the opened root group."""
+        """Persist NGFF metadata to the root group."""
         if self.root is None:
             raise RuntimeError("Store must be initialized before writing metadata.")
-
-        md = self.preview_metadata()
-        if self.zarr_format == 2:
-            self.root.attrs["multiscales"] = md["multiscales"]
-            self.root.attrs["omero"] = md["omero"]
-        else:
-            self.root.attrs.update({"ome": md["ome"]})
+        self.root.attrs.update(self.preview_metadata())


### PR DESCRIPTION
Closes #154

## Summary

Adds an `attributes` constructor parameter to `OMEZarrWriter` for writing arbitrary, non-NGFF key/values into the root group's attributes (a low-level escape hatch for custom/namespaced metadata, e.g. a `"bioio"` block). Motivated by `bioio-conversion` wanting to append provenance and other application-specific metadata to their written zarrs — see #154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
