### PR TITLE
feature: surface provenance standard_metadata from the bioio block

### DIFF
--- a/bioio_ome_zarr/reader.py
+++ b/bioio_ome_zarr/reader.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import logging
 import warnings
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -8,6 +9,7 @@ import dask.array as da
 import xarray as xr
 import zarr
 from bioio_base import constants, dimensions, exceptions, io, reader, types
+from bioio_base.standard_metadata import StandardMetadata
 from fsspec.spec import AbstractFileSystem
 from ome_types import OME
 from ome_types.model import Channel, Image, Pixels, PixelType
@@ -571,3 +573,59 @@ class Reader(reader.Reader):
         self.set_scene(original_scene)
         self._ome_metadata = OME(images=images)
         return self._ome_metadata
+
+    # Fields the base reader cannot derive from an OME-Zarr store on its own,
+    # but that bioio-conversion records in the root "bioio" provenance block.
+    # Names are the snake_case StandardMetadata field names as written there.
+    _PROVENANCE_METADATA_FIELDS = (
+        "objective",
+        "row",
+        "column",
+        "binning",
+        "position_index",
+        "imaged_by",
+    )
+
+    @property
+    def standard_metadata(self) -> StandardMetadata:
+        """
+        Standard metadata for the current image.
+
+        Extends the base reader's natively-derived metadata with fields that an
+        OME-Zarr store cannot reconstruct on its own but that bioio-conversion
+        records in the root ``"bioio"`` provenance block (under its
+        ``standard_metadata`` sub-dict): ``objective``, ``row``, ``column``,
+        ``binning``, ``position_index``, ``imaging_datetime`` and ``imaged_by``.
+        When present, these are propagated into the returned metadata.
+        """
+        metadata = super().standard_metadata
+
+        bioio_attrs = self._zarr.attrs.get("bioio")
+        embedded = (
+            bioio_attrs.get("standard_metadata")
+            if isinstance(bioio_attrs, dict)
+            else None
+        )
+        if not isinstance(embedded, dict):
+            return metadata
+
+        for field in self._PROVENANCE_METADATA_FIELDS:
+            value = embedded.get(field)
+            if value is not None:
+                setattr(metadata, field, value)
+
+        # imaging_datetime is JSON-serialized as an ISO 8601 string; parse back.
+        raw_datetime = embedded.get("imaging_datetime")
+        if isinstance(raw_datetime, datetime):
+            metadata.imaging_datetime = raw_datetime
+        elif raw_datetime is not None:
+            try:
+                metadata.imaging_datetime = datetime.fromisoformat(str(raw_datetime))
+            except ValueError:
+                warnings.warn(
+                    f"Could not parse imaging_datetime {raw_datetime!r} from the "
+                    "'bioio' provenance block; leaving it unset.",
+                    UserWarning,
+                )
+
+        return metadata

--- a/bioio_ome_zarr/reader.py
+++ b/bioio_ome_zarr/reader.py
@@ -580,9 +580,8 @@ class Reader(reader.Reader):
         The ``standard_metadata`` sub-dict of the root ``"bioio"`` block.
 
         bioio-conversion records the source image's cross-format
-        ``StandardMetadata`` here (snake_case field names) for fields an
-        OME-Zarr store cannot reconstruct on its own. Returns an empty dict
-        when the block is absent or malformed.
+        ``StandardMetadata`` here for fields an OME-Zarr store cannot
+        reconstruct on its own.
         """
         bioio_attrs = self._zarr.attrs.get("bioio")
         if isinstance(bioio_attrs, dict):
@@ -593,42 +592,37 @@ class Reader(reader.Reader):
 
     @property
     def objective(self) -> Optional[str]:
-        """Objective recorded in the 'bioio' provenance block, if present."""
+        """Objective recorded in the 'bioio' provenance block."""
         return self._embedded_standard_metadata.get("objective")
 
     @property
     def row(self) -> Optional[str]:
-        """Well row recorded in the 'bioio' provenance block, if present."""
+        """Well row recorded in the 'bioio' provenance block."""
         return self._embedded_standard_metadata.get("row")
 
     @property
     def column(self) -> Optional[str]:
-        """Well column recorded in the 'bioio' provenance block, if present."""
+        """Well column recorded in the 'bioio' provenance block."""
         return self._embedded_standard_metadata.get("column")
 
     @property
     def binning(self) -> Optional[str]:
-        """Binning recorded in the 'bioio' provenance block, if present."""
+        """Binning recorded in the 'bioio' provenance block."""
         return self._embedded_standard_metadata.get("binning")
 
     @property
     def position_index(self) -> Optional[int]:
-        """Position index recorded in the 'bioio' provenance block, if present."""
+        """Position index recorded in the 'bioio' provenance block."""
         return self._embedded_standard_metadata.get("position_index")
 
     @property
     def imaged_by(self) -> Optional[str]:
-        """Experimenter recorded in the 'bioio' provenance block, if present."""
+        """Experimenter recorded in the 'bioio' provenance block."""
         return self._embedded_standard_metadata.get("imaged_by")
 
     @property
     def imaging_datetime(self) -> Optional[datetime]:
-        """
-        Acquisition datetime from the 'bioio' provenance block, if present.
-
-        Stored as an ISO 8601 string; parsed back to a ``datetime``. A
-        malformed value is logged and treated as absent.
-        """
+        """Acquisition datetime from the 'bioio' provenance block."""
         raw = self._embedded_standard_metadata.get("imaging_datetime")
         if raw is None or isinstance(raw, datetime):
             return raw
@@ -639,45 +633,42 @@ class Reader(reader.Reader):
             return None
 
     @property
-    def _time_interval_seconds(self) -> Optional[float]:
-        """
-        The T-axis interval in seconds, or None if there is no time axis.
-
-        ``time_interval`` is the raw T-axis scale; this converts it to seconds
-        using the axis unit the reader parses (see ``dimension_properties``).
-        Falls back to treating the scale as seconds when no unit is recorded or
-        the conversion fails.
-        """
+    def timelapse_interval(self) -> Optional[timedelta]:
+        """Average interval between timepoints."""
         interval = self.time_interval
         if interval is None:
             return None
         unit = self.dimension_properties.T.unit
-        if unit is None:
-            return float(interval)
-        try:
-            return float((interval * unit).to(types.ureg.second).magnitude)
-        except Exception as exc:
-            log.warning(
-                "Could not convert T interval %r %s to seconds: %s",
-                interval,
-                unit,
-                exc,
-            )
-            return float(interval)
+        seconds = float(interval)
+        if unit is not None:
+            try:
+                seconds = float((interval * unit).to(types.ureg.second).magnitude)
+            except Exception as exc:
+                log.warning(
+                    "Could not convert T interval %r %s to seconds: %s",
+                    interval,
+                    unit,
+                    exc,
+                )
+        return timedelta(seconds=seconds)
+
+    @property
+    def total_time_duration(self) -> Optional[timedelta]:
+        """Duration from the first to the last timepoint."""
+        interval = self.timelapse_interval
+        size_t = getattr(self.dims, dimensions.DimensionNames.Time, None)
+        if interval is None or size_t is None or size_t < 2:
+            return None
+        return interval * (size_t - 1)
 
     @property
     def standard_metadata(self) -> StandardMetadata:
         """
-        Return the standard metadata for this reader, updating specific fields.
+         Return the standard metadata for this reader, updating specific fields.
 
-        This implementation calls the base reader's standard_metadata property
-        via super() and then assigns:
-
-        * fields recorded in the root "bioio" provenance block (written by
-          bioio-conversion) that an OME-Zarr store cannot derive on its own, and
-        * the T-based durations (``timelapse_interval``, ``total_time_duration``)
-          derived from the T-axis scale and unit, which the base reader leaves
-          unset for OME-Zarr because it has no per-plane timing.
+         Extends the base reader's metadata with the "bioio" provenance fields
+        and the T-based durations, which an
+         OME-Zarr store does not otherwise populate.
         """
         metadata = super().standard_metadata
         metadata.objective = self.objective
@@ -687,14 +678,6 @@ class Reader(reader.Reader):
         metadata.position_index = self.position_index
         metadata.imaging_datetime = self.imaging_datetime
         metadata.imaged_by = self.imaged_by
-
-        interval_seconds = self._time_interval_seconds
-        if interval_seconds is not None:
-            metadata.timelapse_interval = timedelta(seconds=interval_seconds)
-            size_t = getattr(self.dims, dimensions.DimensionNames.Time, None)
-            if size_t is not None and size_t >= 2:
-                metadata.total_time_duration = timedelta(
-                    seconds=interval_seconds * (size_t - 1)
-                )
-
+        metadata.timelapse_interval = self.timelapse_interval
+        metadata.total_time_duration = self.total_time_duration
         return metadata

--- a/bioio_ome_zarr/reader.py
+++ b/bioio_ome_zarr/reader.py
@@ -574,58 +574,86 @@ class Reader(reader.Reader):
         self._ome_metadata = OME(images=images)
         return self._ome_metadata
 
-    # Fields the base reader cannot derive from an OME-Zarr store on its own,
-    # but that bioio-conversion records in the root "bioio" provenance block.
-    # Names are the snake_case StandardMetadata field names as written there.
-    _PROVENANCE_METADATA_FIELDS = (
-        "objective",
-        "row",
-        "column",
-        "binning",
-        "position_index",
-        "imaged_by",
-    )
+    @property
+    def _embedded_standard_metadata(self) -> Dict[str, Any]:
+        """
+        The ``standard_metadata`` sub-dict of the root ``"bioio"`` block.
+
+        bioio-conversion records the source image's cross-format
+        ``StandardMetadata`` here (snake_case field names) for fields an
+        OME-Zarr store cannot reconstruct on its own. Returns an empty dict
+        when the block is absent or malformed.
+        """
+        bioio_attrs = self._zarr.attrs.get("bioio")
+        if isinstance(bioio_attrs, dict):
+            embedded = bioio_attrs.get("standard_metadata")
+            if isinstance(embedded, dict):
+                return embedded
+        return {}
+
+    @property
+    def objective(self) -> Optional[str]:
+        """Objective recorded in the 'bioio' provenance block, if present."""
+        return self._embedded_standard_metadata.get("objective")
+
+    @property
+    def row(self) -> Optional[str]:
+        """Well row recorded in the 'bioio' provenance block, if present."""
+        return self._embedded_standard_metadata.get("row")
+
+    @property
+    def column(self) -> Optional[str]:
+        """Well column recorded in the 'bioio' provenance block, if present."""
+        return self._embedded_standard_metadata.get("column")
+
+    @property
+    def binning(self) -> Optional[str]:
+        """Binning recorded in the 'bioio' provenance block, if present."""
+        return self._embedded_standard_metadata.get("binning")
+
+    @property
+    def position_index(self) -> Optional[int]:
+        """Position index recorded in the 'bioio' provenance block, if present."""
+        return self._embedded_standard_metadata.get("position_index")
+
+    @property
+    def imaged_by(self) -> Optional[str]:
+        """Experimenter recorded in the 'bioio' provenance block, if present."""
+        return self._embedded_standard_metadata.get("imaged_by")
+
+    @property
+    def imaging_datetime(self) -> Optional[datetime]:
+        """
+        Acquisition datetime from the 'bioio' provenance block, if present.
+
+        Stored as an ISO 8601 string; parsed back to a ``datetime``. A
+        malformed value is logged and treated as absent.
+        """
+        raw = self._embedded_standard_metadata.get("imaging_datetime")
+        if raw is None or isinstance(raw, datetime):
+            return raw
+        try:
+            return datetime.fromisoformat(str(raw))
+        except ValueError as exc:
+            log.warning("Failed to parse imaging_datetime %r: %s", raw, exc)
+            return None
 
     @property
     def standard_metadata(self) -> StandardMetadata:
         """
-        Standard metadata for the current image.
+        Return the standard metadata for this reader, updating specific fields.
 
-        Extends the base reader's natively-derived metadata with fields that an
-        OME-Zarr store cannot reconstruct on its own but that bioio-conversion
-        records in the root ``"bioio"`` provenance block (under its
-        ``standard_metadata`` sub-dict): ``objective``, ``row``, ``column``,
-        ``binning``, ``position_index``, ``imaging_datetime`` and ``imaged_by``.
-        When present, these are propagated into the returned metadata.
+        This implementation calls the base reader's standard_metadata property
+        via super() and then assigns the values recorded in the root "bioio"
+        provenance block (written by bioio-conversion) for fields an OME-Zarr
+        store cannot derive on its own.
         """
         metadata = super().standard_metadata
-
-        bioio_attrs = self._zarr.attrs.get("bioio")
-        embedded = (
-            bioio_attrs.get("standard_metadata")
-            if isinstance(bioio_attrs, dict)
-            else None
-        )
-        if not isinstance(embedded, dict):
-            return metadata
-
-        for field in self._PROVENANCE_METADATA_FIELDS:
-            value = embedded.get(field)
-            if value is not None:
-                setattr(metadata, field, value)
-
-        # imaging_datetime is JSON-serialized as an ISO 8601 string; parse back.
-        raw_datetime = embedded.get("imaging_datetime")
-        if isinstance(raw_datetime, datetime):
-            metadata.imaging_datetime = raw_datetime
-        elif raw_datetime is not None:
-            try:
-                metadata.imaging_datetime = datetime.fromisoformat(str(raw_datetime))
-            except ValueError:
-                warnings.warn(
-                    f"Could not parse imaging_datetime {raw_datetime!r} from the "
-                    "'bioio' provenance block; leaving it unset.",
-                    UserWarning,
-                )
-
+        metadata.objective = self.objective
+        metadata.row = self.row
+        metadata.column = self.column
+        metadata.binning = self.binning
+        metadata.position_index = self.position_index
+        metadata.imaging_datetime = self.imaging_datetime
+        metadata.imaged_by = self.imaged_by
         return metadata

--- a/bioio_ome_zarr/reader.py
+++ b/bioio_ome_zarr/reader.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import logging
 import warnings
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -639,14 +639,45 @@ class Reader(reader.Reader):
             return None
 
     @property
+    def _time_interval_seconds(self) -> Optional[float]:
+        """
+        The T-axis interval in seconds, or None if there is no time axis.
+
+        ``time_interval`` is the raw T-axis scale; this converts it to seconds
+        using the axis unit the reader parses (see ``dimension_properties``).
+        Falls back to treating the scale as seconds when no unit is recorded or
+        the conversion fails.
+        """
+        interval = self.time_interval
+        if interval is None:
+            return None
+        unit = self.dimension_properties.T.unit
+        if unit is None:
+            return float(interval)
+        try:
+            return float((interval * unit).to(types.ureg.second).magnitude)
+        except Exception as exc:
+            log.warning(
+                "Could not convert T interval %r %s to seconds: %s",
+                interval,
+                unit,
+                exc,
+            )
+            return float(interval)
+
+    @property
     def standard_metadata(self) -> StandardMetadata:
         """
         Return the standard metadata for this reader, updating specific fields.
 
         This implementation calls the base reader's standard_metadata property
-        via super() and then assigns the values recorded in the root "bioio"
-        provenance block (written by bioio-conversion) for fields an OME-Zarr
-        store cannot derive on its own.
+        via super() and then assigns:
+
+        * fields recorded in the root "bioio" provenance block (written by
+          bioio-conversion) that an OME-Zarr store cannot derive on its own, and
+        * the T-based durations (``timelapse_interval``, ``total_time_duration``)
+          derived from the T-axis scale and unit, which the base reader leaves
+          unset for OME-Zarr because it has no per-plane timing.
         """
         metadata = super().standard_metadata
         metadata.objective = self.objective
@@ -656,4 +687,14 @@ class Reader(reader.Reader):
         metadata.position_index = self.position_index
         metadata.imaging_datetime = self.imaging_datetime
         metadata.imaged_by = self.imaged_by
+
+        interval_seconds = self._time_interval_seconds
+        if interval_seconds is not None:
+            metadata.timelapse_interval = timedelta(seconds=interval_seconds)
+            size_t = getattr(self.dims, dimensions.DimensionNames.Time, None)
+            if size_t is not None and size_t >= 2:
+                metadata.total_time_duration = timedelta(
+                    seconds=interval_seconds * (size_t - 1)
+                )
+
         return metadata

--- a/bioio_ome_zarr/reader.py
+++ b/bioio_ome_zarr/reader.py
@@ -655,6 +655,16 @@ class Reader(reader.Reader):
         return self._embedded_standard_metadata.get("imaged_by")
 
     @property
+    def stage_position_x(self) -> Optional[float]:
+        """Stage X position (µm) recorded in the source provenance sidecar."""
+        return self._embedded_standard_metadata.get("stage_position_x")
+
+    @property
+    def stage_position_y(self) -> Optional[float]:
+        """Stage Y position (µm) recorded in the source provenance sidecar."""
+        return self._embedded_standard_metadata.get("stage_position_y")
+
+    @property
     def imaging_datetime(self) -> Optional[datetime]:
         """Acquisition datetime from the source provenance sidecar."""
         raw = self._embedded_standard_metadata.get("imaging_datetime")
@@ -746,6 +756,8 @@ class Reader(reader.Reader):
         metadata.position_index = self.position_index
         metadata.imaging_datetime = self.imaging_datetime
         metadata.imaged_by = self.imaged_by
+        metadata.stage_position_x = self.stage_position_x
+        metadata.stage_position_y = self.stage_position_y
         metadata.timelapse_interval = self.timelapse_interval
         metadata.total_time_duration = self.total_time_duration
         return metadata

--- a/bioio_ome_zarr/reader.py
+++ b/bioio_ome_zarr/reader.py
@@ -23,8 +23,9 @@ from . import utils as metadata_utils
 
 log = logging.getLogger(__name__)
 
-# Root attributes key under which bioio-conversion records source provenance.
+# Provenance names mirrored from ``bioio_conversion.provenance``.
 PROVENANCE_ATTR_KEY = "bioio_conversion"
+STANDARD_METADATA_KEY = "standard_metadata"
 
 ###############################################################################
 
@@ -586,7 +587,7 @@ class Reader(reader.Reader):
         if not isinstance(block, dict):
             return {}
 
-        rel_path = block.get("standard_metadata")
+        rel_path = block.get(STANDARD_METADATA_KEY)
         if not isinstance(rel_path, str):
             return {}
 

--- a/bioio_ome_zarr/reader.py
+++ b/bioio_ome_zarr/reader.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import json
 import logging
 import warnings
 from datetime import datetime, timedelta
@@ -21,6 +22,9 @@ from . import utils as metadata_utils
 ###############################################################################
 
 log = logging.getLogger(__name__)
+
+# Root attributes key under which bioio-conversion records source provenance.
+PROVENANCE_ATTR_KEY = "bioio_conversion"
 
 ###############################################################################
 
@@ -46,6 +50,8 @@ class Reader(reader.Reader):
 
     _fs: AbstractFileSystem
     _path: str
+
+    _provenance_standard_metadata: Optional[Dict[str, Any]] = None
 
     _current_scene_index: int = 0
 
@@ -574,55 +580,82 @@ class Reader(reader.Reader):
         self._ome_metadata = OME(images=images)
         return self._ome_metadata
 
+    def _read_standard_metadata_sidecar(self) -> Dict[str, Any]:
+        """Load the ``standard_metadata`` sidecar named by the provenance block."""
+        block = self._zarr.attrs.get(PROVENANCE_ATTR_KEY)
+        if not isinstance(block, dict):
+            return {}
+
+        rel_path = block.get("standard_metadata")
+        if not isinstance(rel_path, str):
+            return {}
+
+        sidecar_path = f"{self._path.rstrip('/')}/{rel_path}"
+        try:
+            with self._fs.open(sidecar_path, "rb") as open_sidecar:
+                fields = json.load(open_sidecar)
+        except Exception as exc:
+            log.warning(
+                "Could not read standard_metadata sidecar %r: %s", sidecar_path, exc
+            )
+            return {}
+
+        if not isinstance(fields, dict):
+            log.warning(
+                "standard_metadata sidecar %r is not a JSON object, ignoring it.",
+                sidecar_path,
+            )
+            return {}
+        return fields
+
     @property
     def _embedded_standard_metadata(self) -> Dict[str, Any]:
         """
-        The ``standard_metadata`` sub-dict of the root ``"bioio"`` block.
+        The source image's ``StandardMetadata`` fields, as recorded on conversion.
 
-        bioio-conversion records the source image's cross-format
-        ``StandardMetadata`` here for fields an OME-Zarr store cannot
-        reconstruct on its own.
+        bioio-conversion writes the source's cross-format ``StandardMetadata``
+        to a JSON sidecar at the store root and points at it from the root
+        ``"bioio_conversion"`` attributes block, covering fields an OME-Zarr
+        store cannot reconstruct on its own. Read once and cached, since each
+        lookup would otherwise re-fetch the sidecar.
         """
-        bioio_attrs = self._zarr.attrs.get("bioio")
-        if isinstance(bioio_attrs, dict):
-            embedded = bioio_attrs.get("standard_metadata")
-            if isinstance(embedded, dict):
-                return embedded
-        return {}
+        if self._provenance_standard_metadata is None:
+            self._provenance_standard_metadata = self._read_standard_metadata_sidecar()
+        return self._provenance_standard_metadata
 
     @property
     def objective(self) -> Optional[str]:
-        """Objective recorded in the 'bioio' provenance block."""
+        """Objective recorded in the source provenance sidecar."""
         return self._embedded_standard_metadata.get("objective")
 
     @property
     def row(self) -> Optional[str]:
-        """Well row recorded in the 'bioio' provenance block."""
+        """Well row recorded in the source provenance sidecar."""
         return self._embedded_standard_metadata.get("row")
 
     @property
     def column(self) -> Optional[str]:
-        """Well column recorded in the 'bioio' provenance block."""
+        """Well column recorded in the source provenance sidecar."""
         return self._embedded_standard_metadata.get("column")
 
     @property
     def binning(self) -> Optional[str]:
-        """Binning recorded in the 'bioio' provenance block."""
+        """Binning recorded in the source provenance sidecar."""
         return self._embedded_standard_metadata.get("binning")
 
     @property
     def position_index(self) -> Optional[int]:
-        """Position index recorded in the 'bioio' provenance block."""
+        """Position index recorded in the source provenance sidecar."""
         return self._embedded_standard_metadata.get("position_index")
 
     @property
     def imaged_by(self) -> Optional[str]:
-        """Experimenter recorded in the 'bioio' provenance block."""
+        """Experimenter recorded in the source provenance sidecar."""
         return self._embedded_standard_metadata.get("imaged_by")
 
     @property
     def imaging_datetime(self) -> Optional[datetime]:
-        """Acquisition datetime from the 'bioio' provenance block."""
+        """Acquisition datetime from the source provenance sidecar."""
         raw = self._embedded_standard_metadata.get("imaging_datetime")
         if raw is None or isinstance(raw, datetime):
             return raw
@@ -632,9 +665,34 @@ class Reader(reader.Reader):
             log.warning("Failed to parse imaging_datetime %r: %s", raw, exc)
             return None
 
+    def _recorded_duration(self, field: str) -> Optional[timedelta]:
+        """A provenance duration, recorded as seconds by bioio-conversion."""
+        raw = self._embedded_standard_metadata.get(field)
+        if raw is None:
+            return None
+        try:
+            return timedelta(seconds=float(raw))
+        except (TypeError, ValueError) as exc:
+            log.warning("Failed to parse %s %r: %s", field, raw, exc)
+            return None
+
     @property
     def timelapse_interval(self) -> Optional[timedelta]:
-        """Average interval between timepoints."""
+        """
+        Average interval between timepoints.
+
+        Prefers the interval the source reader measured, since a converted store
+        may carry a nominal T scale rather than the real acquisition timing.
+        Falls back to deriving it from the T scale and unit.
+        """
+        recorded = self._recorded_duration("timelapse_interval")
+        if recorded is not None:
+            return recorded
+
+        size_t = getattr(self.dims, dimensions.DimensionNames.Time, None)
+        if size_t is None or size_t < 2:
+            return None
+
         interval = self.time_interval
         if interval is None:
             return None
@@ -654,7 +712,16 @@ class Reader(reader.Reader):
 
     @property
     def total_time_duration(self) -> Optional[timedelta]:
-        """Duration from the first to the last timepoint."""
+        """
+        Duration from the first to the last timepoint.
+
+        Prefers the duration the source reader measured; otherwise spans the
+        timepoints using :attr:`timelapse_interval`.
+        """
+        recorded = self._recorded_duration("total_time_duration")
+        if recorded is not None:
+            return recorded
+
         interval = self.timelapse_interval
         size_t = getattr(self.dims, dimensions.DimensionNames.Time, None)
         if interval is None or size_t is None or size_t < 2:
@@ -664,11 +731,11 @@ class Reader(reader.Reader):
     @property
     def standard_metadata(self) -> StandardMetadata:
         """
-         Return the standard metadata for this reader, updating specific fields.
+        Return the standard metadata for this reader, updating specific fields.
 
-         Extends the base reader's metadata with the "bioio" provenance fields
-        and the T-based durations, which an
-         OME-Zarr store does not otherwise populate.
+        Extends the base reader's metadata with the source provenance fields and
+        the T-based durations, which an OME-Zarr store does not otherwise
+        populate.
         """
         metadata = super().standard_metadata
         metadata.objective = self.objective

--- a/bioio_ome_zarr/tests/resources/provenance_czi.ome.zarr/0/c/0/0/0
+++ b/bioio_ome_zarr/tests/resources/provenance_czi.ome.zarr/0/c/0/0/0
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:048aa25dce1decc136ac8ad3756b0f00266144a3977cc546fc49f306c4fe3c0e
+size 190908

--- a/bioio_ome_zarr/tests/resources/provenance_czi.ome.zarr/0/zarr.json
+++ b/bioio_ome_zarr/tests/resources/provenance_czi.ome.zarr/0/zarr.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9231719c5d547b04aec7e3a3843d0524a2a7488e3f77e3ea66e965f3410a1ee3
+size 1330

--- a/bioio_ome_zarr/tests/resources/provenance_czi.ome.zarr/metadata.native.json
+++ b/bioio_ome_zarr/tests/resources/provenance_czi.ome.zarr/metadata.native.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca47efe107f7540a05f3053b712b860fcae1f0840d18cbf5137b5f3f31927b8d
+size 214121

--- a/bioio_ome_zarr/tests/resources/provenance_czi.ome.zarr/metadata.ome.json
+++ b/bioio_ome_zarr/tests/resources/provenance_czi.ome.zarr/metadata.ome.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8aae338ee08842582bc3630056cb4e1bc6de219f8fdf9a05f4526ef9da1bfc4
+size 4213

--- a/bioio_ome_zarr/tests/resources/provenance_czi.ome.zarr/standard_metadata.json
+++ b/bioio_ome_zarr/tests/resources/provenance_czi.ome.zarr/standard_metadata.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:64c049c929704b6f6c063b9a361c7f714887eb2f2496e00c13e180fc6e56eec3
-size 476
+oid sha256:f45c2278f9d7e06777e7bc6b0382488711a1a4ec1797f9713ed41ffd0a8fbf35
+size 535

--- a/bioio_ome_zarr/tests/resources/provenance_czi.ome.zarr/standard_metadata.json
+++ b/bioio_ome_zarr/tests/resources/provenance_czi.ome.zarr/standard_metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:64c049c929704b6f6c063b9a361c7f714887eb2f2496e00c13e180fc6e56eec3
+size 476

--- a/bioio_ome_zarr/tests/resources/provenance_czi.ome.zarr/zarr.json
+++ b/bioio_ome_zarr/tests/resources/provenance_czi.ome.zarr/zarr.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2958137c7cfe7f3726d58f72656b67d8980c49daae2521c27a5938480cce950
+size 1832

--- a/bioio_ome_zarr/tests/resources/provenance_nd2_plate.ome.zarr/0/c/0/0/0/0/0
+++ b/bioio_ome_zarr/tests/resources/provenance_nd2_plate.ome.zarr/0/c/0/0/0/0/0
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8af04012c2984181c9223bc21306aa3ec3161e06bb1037b222410cfc63329546
+size 66464

--- a/bioio_ome_zarr/tests/resources/provenance_nd2_plate.ome.zarr/0/zarr.json
+++ b/bioio_ome_zarr/tests/resources/provenance_nd2_plate.ome.zarr/0/zarr.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b654ae15524de24f31cf21ad6b6193feea3aa37706ffdb89eda4c282c0b4452e
+size 1404

--- a/bioio_ome_zarr/tests/resources/provenance_nd2_plate.ome.zarr/metadata.native.json
+++ b/bioio_ome_zarr/tests/resources/provenance_nd2_plate.ome.zarr/metadata.native.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e15f9f489325c6949565db9d8e551872b37bd871ed3829b578961e6230fcea7c
+size 178088

--- a/bioio_ome_zarr/tests/resources/provenance_nd2_plate.ome.zarr/metadata.ome.json
+++ b/bioio_ome_zarr/tests/resources/provenance_nd2_plate.ome.zarr/metadata.ome.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:49923e41c63b9c64d57a5196b9d704d6f6ec68cd61c9a6e053039fe236cea152
+size 178088

--- a/bioio_ome_zarr/tests/resources/provenance_nd2_plate.ome.zarr/standard_metadata.json
+++ b/bioio_ome_zarr/tests/resources/provenance_nd2_plate.ome.zarr/standard_metadata.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0301d01dd8e14cb60b611f83ffa61ec342aa8ea9434de856d2dc40346f0391ff
-size 472
+oid sha256:6a18e6f65178319cc1274021e6b90fb11a1144c7faf319540323da1ac4c6d27b
+size 524

--- a/bioio_ome_zarr/tests/resources/provenance_nd2_plate.ome.zarr/standard_metadata.json
+++ b/bioio_ome_zarr/tests/resources/provenance_nd2_plate.ome.zarr/standard_metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0301d01dd8e14cb60b611f83ffa61ec342aa8ea9434de856d2dc40346f0391ff
+size 472

--- a/bioio_ome_zarr/tests/resources/provenance_nd2_plate.ome.zarr/zarr.json
+++ b/bioio_ome_zarr/tests/resources/provenance_nd2_plate.ome.zarr/zarr.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf226f8be691eb79a5a10a37b3be7a5182e06536c5aeb2db9502ef56ca42c888
+size 3257

--- a/bioio_ome_zarr/tests/resources/provenance_ome_tiff.ome.zarr/0/c/0/0/0/0/0
+++ b/bioio_ome_zarr/tests/resources/provenance_ome_tiff.ome.zarr/0/c/0/0/0/0/0
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9714353ca5156a88cf6fa8f33820f7ce337f98ab9eb62d73831a7c0da8c6218a
+size 1932907

--- a/bioio_ome_zarr/tests/resources/provenance_ome_tiff.ome.zarr/0/zarr.json
+++ b/bioio_ome_zarr/tests/resources/provenance_ome_tiff.ome.zarr/0/zarr.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d1b9d872811314d48907650826ceb6e98f1f3291a2dff7556ea3d19bf3a602f
+size 1410

--- a/bioio_ome_zarr/tests/resources/provenance_ome_tiff.ome.zarr/metadata.ome.json
+++ b/bioio_ome_zarr/tests/resources/provenance_ome_tiff.ome.zarr/metadata.ome.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c9f177ba57cc983346b3f22c31f4e62abf331c71af00785386a4c5eb84a74989
+size 37443

--- a/bioio_ome_zarr/tests/resources/provenance_ome_tiff.ome.zarr/standard_metadata.json
+++ b/bioio_ome_zarr/tests/resources/provenance_ome_tiff.ome.zarr/standard_metadata.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ebe85c1630d4fa46c0a68c4233d3b901a8cf4ed8ff4d8736482cc541880ea042
-size 472
+oid sha256:0c087a811716aab36ec2d76a1c343ef1d22e7593270d87a45ad0fbb843325ffb
+size 524

--- a/bioio_ome_zarr/tests/resources/provenance_ome_tiff.ome.zarr/standard_metadata.json
+++ b/bioio_ome_zarr/tests/resources/provenance_ome_tiff.ome.zarr/standard_metadata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ebe85c1630d4fa46c0a68c4233d3b901a8cf4ed8ff4d8736482cc541880ea042
+size 472

--- a/bioio_ome_zarr/tests/resources/provenance_ome_tiff.ome.zarr/zarr.json
+++ b/bioio_ome_zarr/tests/resources/provenance_ome_tiff.ome.zarr/zarr.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea5d726db546dc312d319559f8f774c61d0e9dccebc3fc41119e2831dcfbb86c
+size 2767

--- a/bioio_ome_zarr/tests/test_reader_zarrV3.py
+++ b/bioio_ome_zarr/tests/test_reader_zarrV3.py
@@ -1,17 +1,12 @@
-import logging
-import pathlib
-from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 import pytest
-import zarr
 from bioio_base import dimensions, exceptions, test_utilities, types
 from ome_types import to_dict
 from zarr.core.group import GroupMetadata
 
 from bioio_ome_zarr import Reader
-from bioio_ome_zarr.writers import OMEZarrWriter
 
 from .conftest import LOCAL_RESOURCES_DIR
 
@@ -344,94 +339,3 @@ def test_read_ome_metadata_channels_no_color() -> None:
     uri = LOCAL_RESOURCES_DIR / "test_ngff_channel_no_color.zarr"
     reader = Reader(uri)
     assert reader.ome_metadata.images[0].pixels.channels[0].name == "random"
-
-
-def _write_store_with_bioio_block(
-    path: pathlib.Path, block: Optional[Dict[str, object]]
-) -> str:
-    """Write a minimal store and inject a root ``"bioio"`` provenance block."""
-    shape = (1, 1, 1, 4, 4)
-    data = np.zeros(shape, dtype=np.uint8)
-    writer = OMEZarrWriter(store=str(path), level_shapes=[shape], dtype=data.dtype)
-    writer.write_full_volume(data)
-    if block is not None:
-        grp = zarr.open_group(str(path), mode="r+")
-        grp.attrs["bioio"] = block
-    return str(path)
-
-
-def test_standard_metadata_from_provenance(tmp_path: pathlib.Path) -> None:
-    """standard_metadata is enriched from the root 'bioio' provenance block."""
-    uri = _write_store_with_bioio_block(
-        tmp_path / "prov.zarr",
-        {
-            "standard_metadata": {
-                "objective": "40x/1.2W",
-                "row": "B",
-                "column": "3",
-                "binning": "2x2",
-                "position_index": 7,
-                "imaging_datetime": "2024-05-01T09:30:00",
-                "imaged_by": "jdoe",
-                # Natively-derivable field: must NOT clobber the reader's value.
-                "image_size_x": 999,
-            }
-        },
-    )
-
-    sm = Reader(uri).standard_metadata
-    assert sm.objective == "40x/1.2W"
-    assert sm.row == "B"
-    assert sm.column == "3"
-    assert sm.binning == "2x2"
-    assert sm.position_index == 7
-    assert sm.imaging_datetime == datetime(2024, 5, 1, 9, 30, 0)
-    assert sm.imaged_by == "jdoe"
-    # image_size_x stays natively derived (4), not overridden by the block.
-    assert sm.image_size_x == 4
-
-
-def test_standard_metadata_time_durations_native(tmp_path: pathlib.Path) -> None:
-    """timelapse_interval / total_time_duration derive from the T scale + unit."""
-    save_uri = tmp_path / "time.zarr"
-    shape = (4, 1, 1, 2, 2)  # T=4
-    data = np.zeros(shape, dtype=np.uint8)
-    writer = OMEZarrWriter(
-        store=str(save_uri),
-        level_shapes=[shape],
-        dtype=data.dtype,
-        axes_names=["t", "c", "z", "y", "x"],
-        axes_units=["second", None, None, None, None],
-        physical_pixel_size=[2.0, 1.0, 1.0, 1.0, 1.0],  # 2s between timepoints
-    )
-    writer.write_full_volume(data)
-
-    sm = Reader(str(save_uri)).standard_metadata
-    assert sm.timelapse_interval == timedelta(seconds=2.0)
-    # First -> last timepoint: interval * (T - 1) = 2s * 3.
-    assert sm.total_time_duration == timedelta(seconds=6.0)
-
-
-def test_standard_metadata_without_provenance(tmp_path: pathlib.Path) -> None:
-    """Without a 'bioio' block, provenance-only fields stay unset."""
-    uri = _write_store_with_bioio_block(tmp_path / "no_prov.zarr", None)
-    sm = Reader(uri).standard_metadata
-    assert sm.objective is None
-    assert sm.row is None
-    assert sm.position_index is None
-    # Natively-derived fields are still populated.
-    assert sm.image_size_x == 4
-
-
-def test_standard_metadata_bad_datetime_warns(
-    tmp_path: pathlib.Path, caplog: pytest.LogCaptureFixture
-) -> None:
-    """A malformed imaging_datetime is logged and left unset."""
-    uri = _write_store_with_bioio_block(
-        tmp_path / "bad_dt.zarr",
-        {"standard_metadata": {"imaging_datetime": "not-a-date"}},
-    )
-    with caplog.at_level(logging.WARNING):
-        sm = Reader(uri).standard_metadata
-    assert sm.imaging_datetime is None
-    assert "imaging_datetime" in caplog.text

--- a/bioio_ome_zarr/tests/test_reader_zarrV3.py
+++ b/bioio_ome_zarr/tests/test_reader_zarrV3.py
@@ -1,6 +1,6 @@
 import logging
 import pathlib
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Tuple
 
 import numpy as np
@@ -389,6 +389,27 @@ def test_standard_metadata_from_provenance(tmp_path: pathlib.Path) -> None:
     assert sm.imaged_by == "jdoe"
     # image_size_x stays natively derived (4), not overridden by the block.
     assert sm.image_size_x == 4
+
+
+def test_standard_metadata_time_durations_native(tmp_path: pathlib.Path) -> None:
+    """timelapse_interval / total_time_duration derive from the T scale + unit."""
+    save_uri = tmp_path / "time.zarr"
+    shape = (4, 1, 1, 2, 2)  # T=4
+    data = np.zeros(shape, dtype=np.uint8)
+    writer = OMEZarrWriter(
+        store=str(save_uri),
+        level_shapes=[shape],
+        dtype=data.dtype,
+        axes_names=["t", "c", "z", "y", "x"],
+        axes_units=["second", None, None, None, None],
+        physical_pixel_size=[2.0, 1.0, 1.0, 1.0, 1.0],  # 2s between timepoints
+    )
+    writer.write_full_volume(data)
+
+    sm = Reader(str(save_uri)).standard_metadata
+    assert sm.timelapse_interval == timedelta(seconds=2.0)
+    # First -> last timepoint: interval * (T - 1) = 2s * 3.
+    assert sm.total_time_duration == timedelta(seconds=6.0)
 
 
 def test_standard_metadata_without_provenance(tmp_path: pathlib.Path) -> None:

--- a/bioio_ome_zarr/tests/test_reader_zarrV3.py
+++ b/bioio_ome_zarr/tests/test_reader_zarrV3.py
@@ -1,3 +1,4 @@
+import logging
 import pathlib
 from datetime import datetime
 from typing import Dict, List, Optional, Tuple
@@ -401,12 +402,15 @@ def test_standard_metadata_without_provenance(tmp_path: pathlib.Path) -> None:
     assert sm.image_size_x == 4
 
 
-def test_standard_metadata_bad_datetime_warns(tmp_path: pathlib.Path) -> None:
-    """A malformed imaging_datetime warns and is left unset."""
+def test_standard_metadata_bad_datetime_warns(
+    tmp_path: pathlib.Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A malformed imaging_datetime is logged and left unset."""
     uri = _write_store_with_bioio_block(
         tmp_path / "bad_dt.zarr",
         {"standard_metadata": {"imaging_datetime": "not-a-date"}},
     )
-    with pytest.warns(UserWarning, match="imaging_datetime"):
+    with caplog.at_level(logging.WARNING):
         sm = Reader(uri).standard_metadata
     assert sm.imaging_datetime is None
+    assert "imaging_datetime" in caplog.text

--- a/bioio_ome_zarr/tests/test_reader_zarrV3.py
+++ b/bioio_ome_zarr/tests/test_reader_zarrV3.py
@@ -1,12 +1,16 @@
+import pathlib
+from datetime import datetime
 from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 import pytest
+import zarr
 from bioio_base import dimensions, exceptions, test_utilities, types
 from ome_types import to_dict
 from zarr.core.group import GroupMetadata
 
 from bioio_ome_zarr import Reader
+from bioio_ome_zarr.writers import OMEZarrWriter
 
 from .conftest import LOCAL_RESOURCES_DIR
 
@@ -339,3 +343,70 @@ def test_read_ome_metadata_channels_no_color() -> None:
     uri = LOCAL_RESOURCES_DIR / "test_ngff_channel_no_color.zarr"
     reader = Reader(uri)
     assert reader.ome_metadata.images[0].pixels.channels[0].name == "random"
+
+
+def _write_store_with_bioio_block(
+    path: pathlib.Path, block: Optional[Dict[str, object]]
+) -> str:
+    """Write a minimal store and inject a root ``"bioio"`` provenance block."""
+    shape = (1, 1, 1, 4, 4)
+    data = np.zeros(shape, dtype=np.uint8)
+    writer = OMEZarrWriter(store=str(path), level_shapes=[shape], dtype=data.dtype)
+    writer.write_full_volume(data)
+    if block is not None:
+        grp = zarr.open_group(str(path), mode="r+")
+        grp.attrs["bioio"] = block
+    return str(path)
+
+
+def test_standard_metadata_from_provenance(tmp_path: pathlib.Path) -> None:
+    """standard_metadata is enriched from the root 'bioio' provenance block."""
+    uri = _write_store_with_bioio_block(
+        tmp_path / "prov.zarr",
+        {
+            "standard_metadata": {
+                "objective": "40x/1.2W",
+                "row": "B",
+                "column": "3",
+                "binning": "2x2",
+                "position_index": 7,
+                "imaging_datetime": "2024-05-01T09:30:00",
+                "imaged_by": "jdoe",
+                # Natively-derivable field: must NOT clobber the reader's value.
+                "image_size_x": 999,
+            }
+        },
+    )
+
+    sm = Reader(uri).standard_metadata
+    assert sm.objective == "40x/1.2W"
+    assert sm.row == "B"
+    assert sm.column == "3"
+    assert sm.binning == "2x2"
+    assert sm.position_index == 7
+    assert sm.imaging_datetime == datetime(2024, 5, 1, 9, 30, 0)
+    assert sm.imaged_by == "jdoe"
+    # image_size_x stays natively derived (4), not overridden by the block.
+    assert sm.image_size_x == 4
+
+
+def test_standard_metadata_without_provenance(tmp_path: pathlib.Path) -> None:
+    """Without a 'bioio' block, provenance-only fields stay unset."""
+    uri = _write_store_with_bioio_block(tmp_path / "no_prov.zarr", None)
+    sm = Reader(uri).standard_metadata
+    assert sm.objective is None
+    assert sm.row is None
+    assert sm.position_index is None
+    # Natively-derived fields are still populated.
+    assert sm.image_size_x == 4
+
+
+def test_standard_metadata_bad_datetime_warns(tmp_path: pathlib.Path) -> None:
+    """A malformed imaging_datetime warns and is left unset."""
+    uri = _write_store_with_bioio_block(
+        tmp_path / "bad_dt.zarr",
+        {"standard_metadata": {"imaging_datetime": "not-a-date"}},
+    )
+    with pytest.warns(UserWarning, match="imaging_datetime"):
+        sm = Reader(uri).standard_metadata
+    assert sm.imaging_datetime is None

--- a/bioio_ome_zarr/tests/test_reader_zarrV3.py
+++ b/bioio_ome_zarr/tests/test_reader_zarrV3.py
@@ -360,6 +360,8 @@ def test_read_ome_metadata_channels_no_color() -> None:
                 "row": None,
                 "column": None,
                 "position_index": None,
+                "stage_position_x": 12345.67,
+                "stage_position_y": 2345.89,
                 # Single timepoint: the source measured no timing.
                 "timelapse_interval": None,
                 "total_time_duration": None,
@@ -376,6 +378,8 @@ def test_read_ome_metadata_channels_no_color() -> None:
                 "row": None,
                 "column": None,
                 "position_index": None,
+                "stage_position_x": None,
+                "stage_position_y": None,
                 "timelapse_interval": None,
                 # Recorded by the source reader, in seconds.
                 "total_time_duration": timedelta(seconds=5.245),
@@ -402,6 +406,8 @@ def test_read_ome_metadata_channels_no_color() -> None:
                 "row": "4",
                 "column": "3",
                 "position_index": None,
+                "stage_position_x": None,
+                "stage_position_y": None,
                 # Real acquisition timing, not the store's nominal T scale of 1.0.
                 "timelapse_interval": timedelta(seconds=18.49526),
                 "total_time_duration": timedelta(seconds=73.981041),
@@ -451,5 +457,7 @@ def test_standard_metadata_without_provenance() -> None:
     assert standard_metadata.binning is None
     assert standard_metadata.imaged_by is None
     assert standard_metadata.imaging_datetime is None
+    assert standard_metadata.stage_position_x is None
+    assert standard_metadata.stage_position_y is None
     # Natively-derived fields are still populated.
     assert standard_metadata.image_size_x is not None

--- a/bioio_ome_zarr/tests/test_reader_zarrV3.py
+++ b/bioio_ome_zarr/tests/test_reader_zarrV3.py
@@ -1,4 +1,5 @@
-from typing import Dict, List, Optional, Tuple
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 import pytest
@@ -339,3 +340,116 @@ def test_read_ome_metadata_channels_no_color() -> None:
     uri = LOCAL_RESOURCES_DIR / "test_ngff_channel_no_color.zarr"
     reader = Reader(uri)
     assert reader.ome_metadata.images[0].pixels.channels[0].name == "random"
+
+
+# Stores converted by bioio-conversion with include_provenance=True. Each carries
+# a root "bioio_conversion" attributes block pointing at a standard_metadata.json
+# sidecar holding the source reader's StandardMetadata.
+@pytest.mark.parametrize(
+    "filename, expected",
+    [
+        pytest.param(
+            "provenance_czi.ome.zarr",
+            {
+                "objective": "20x/0.8Air",
+                "binning": "4x4",
+                "imaged_by": "ruiany",
+                "imaging_datetime": datetime(
+                    2019, 6, 27, 18, 33, 40, 619371, tzinfo=timezone.utc
+                ),
+                "row": None,
+                "column": None,
+                "position_index": None,
+                # Single timepoint: the source measured no timing.
+                "timelapse_interval": None,
+                "total_time_duration": None,
+            },
+            id="czi",
+        ),
+        pytest.param(
+            "provenance_ome_tiff.ome.zarr",
+            {
+                "objective": "20x/0.8Air",
+                "binning": "4x4",
+                "imaged_by": "ruiany",
+                "imaging_datetime": datetime(2019, 6, 27, 18, 39, 25, 807000),
+                "row": None,
+                "column": None,
+                "position_index": None,
+                "timelapse_interval": None,
+                # Recorded by the source reader, in seconds.
+                "total_time_duration": timedelta(seconds=5.245),
+            },
+            id="ome-tiff",
+        ),
+        pytest.param(
+            "provenance_nd2_plate.ome.zarr",
+            {
+                "objective": "10x/0.3",
+                "binning": "1x1",
+                "imaged_by": None,
+                "imaging_datetime": datetime(
+                    2021,
+                    9,
+                    28,
+                    6,
+                    55,
+                    1,
+                    935004,
+                    tzinfo=timezone(timedelta(hours=-7)),
+                ),
+                # Plate-derived well, from a provenance reader opened with plate=96.
+                "row": "4",
+                "column": "3",
+                "position_index": None,
+                # Real acquisition timing, not the store's nominal T scale of 1.0.
+                "timelapse_interval": timedelta(seconds=18.49526),
+                "total_time_duration": timedelta(seconds=73.981041),
+            },
+            id="nd2-plate",
+        ),
+    ],
+)
+def test_standard_metadata_from_provenance(
+    filename: str, expected: Dict[str, Any]
+) -> None:
+    """Provenance-only fields are surfaced from the standard_metadata sidecar."""
+    reader = Reader(LOCAL_RESOURCES_DIR / filename)
+    metadata = reader.standard_metadata
+
+    for field, value in expected.items():
+        assert getattr(metadata, field) == value, field
+        # The same value is exposed as a reader property.
+        assert getattr(reader, field) == value, field
+
+
+@pytest.mark.parametrize(
+    "filename, expected_size_x, expected_size_y",
+    [
+        ("provenance_czi.ome.zarr", 475, 325),
+        ("provenance_ome_tiff.ome.zarr", 475, 325),
+        ("provenance_nd2_plate.ome.zarr", 32, 32),
+    ],
+)
+def test_standard_metadata_natively_derived_fields_win(
+    filename: str, expected_size_x: int, expected_size_y: int
+) -> None:
+    """Fields the store itself describes stay natively derived, not read from the
+    sidecar."""
+    metadata = Reader(LOCAL_RESOURCES_DIR / filename).standard_metadata
+    assert metadata.image_size_x == expected_size_x
+    assert metadata.image_size_y == expected_size_y
+
+
+def test_standard_metadata_without_provenance() -> None:
+    """Without a provenance block, provenance-only fields stay unset."""
+    metadata = Reader(LOCAL_RESOURCES_DIR / "s1_t1_c1_z1_Image_0_V3.zarr")
+    standard_metadata = metadata.standard_metadata
+    assert standard_metadata.objective is None
+    assert standard_metadata.row is None
+    assert standard_metadata.column is None
+    assert standard_metadata.binning is None
+    assert standard_metadata.imaged_by is None
+    assert standard_metadata.imaging_datetime is None
+    # Natively-derived fields are still populated.
+    assert standard_metadata.image_size_x is not None


### PR DESCRIPTION
### Link to Relevant Issue

Follow-up tracked in #156.
Depends on the provenance contract defined in bioio-devs/bioio-conversion#63.

### Description of Changes

Overrides `standard_metadata` on the OME-Zarr `Reader` to enrich the base reader's natively-derived fields with values an OME-Zarr store cannot reconstruct on its own. Follows the `standard_metadata` convention.

Also adds derivation of time related annotations from scale/units

### Tasks / follow-ups

- [x] Need to know the prov contract first (confirm the `bioio.standard_metadata` schema against bioio-devs/bioio-conversion#63)
- [x] Make test files (real OME-Zarr stores with provenance data) and add reader tests
